### PR TITLE
Restore QR scanner and unify FAB margin

### DIFF
--- a/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
@@ -13,6 +13,7 @@ import android.widget.*
 import androidx.fragment.app.Fragment
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
+import com.journeyapps.barcodescanner.ScanOptions
 import com.squareup.picasso.Picasso
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
@@ -548,8 +549,14 @@ private fun afterLogout(view: View) {
     }
 
     private fun startQrScanner() {
-        // Используй свою ActivityResult/Intent для сканирования QR (ZXing и т.п.)
-        // ...
+        val options = ScanOptions().apply {
+            setDesiredBarcodeFormats(ScanOptions.QR_CODE)
+            setPrompt("Сканируйте QR для передачи сессии")
+            setCameraId(0)
+            setBeepEnabled(true)
+            setBarcodeImageEnabled(false)
+        }
+        qrScanLauncher.launch(options.createScanIntent(requireContext()))
     }
 
     private fun downloadConfig(token: String, serverId: String, tunnelName: String, callback: (Boolean, String?) -> Unit) {

--- a/ui/src/main/res/layout/fragment_account.xml
+++ b/ui/src/main/res/layout/fragment_account.xml
@@ -146,5 +146,5 @@
         android:src="@android:drawable/ic_menu_camera"
         android:contentDescription="Сканировать QR"
         android:layout_gravity="bottom|end"
-        android:layout_margin="28dp" />
+        android:layout_margin="@dimen/fab_margin" />
 </androidx.coordinatorlayout.widget.CoordinatorLayout>


### PR DESCRIPTION
## Summary
- re-enable QR scanning with ZXing in `AccountFragment`
- add missing import for `ScanOptions`
- align the account screen FAB margin with other screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e3ae063c8326bb25fb70df8e2dec