### PR TITLE
Fix QR login confirmation payload

### DIFF
--- a/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
@@ -531,11 +531,10 @@ private fun afterLogout(view: View) {
             return
         }
         val client = OkHttpClient()
-        val json = """{"token":"$token"}"""
-        val body = json.toRequestBody("application/json".toMediaType())
+        val payload = """{"token":"$token","session":"$jwt"}"""
+        val body = payload.toRequestBody("application/json".toMediaType())
         val request = Request.Builder()
             .url("https://idrug.pw/api/qr/login_confirm")
-            .addHeader("Authorization", "Bearer $jwt")
             .post(body)
             .build()
         client.newCall(request).enqueue(object : Callback {


### PR DESCRIPTION
## Summary
- send session token in payload when confirming QR login

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842e03e6774832689d637a25ada9b87