### PR TITLE
Refactor package to pw.idrug.connections

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 amneziawgVersionCode=5
 amneziawgVersionName=1.1.2
-amneziawgPackageName=org.amnezia.awg
+amneziawgPackageName=pw.idrug.connections
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -21,7 +21,7 @@ plugins {
     id("com.android.settings") version "8.3.0"
 }
 
-rootProject.name = "amneziawg-android"
+rootProject.name = "idrugconnections-android"
 
 include(":tunnel")
 include(":ui")

--- a/tunnel/src/main/AndroidManifest.xml
+++ b/tunnel/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 
     <application>
         <service
-            android:name="org.amnezia.awg.backend.GoBackend$VpnService"
+            android:name="pw.idrug.connections.backend.GoBackend$VpnService"
             android:permission="android.permission.BIND_VPN_SERVICE"
             android:exported="false">
             <intent-filter>

--- a/tunnel/src/main/java/org/amnezia/awg/GoBackend.java
+++ b/tunnel/src/main/java/org/amnezia/awg/GoBackend.java
@@ -1,4 +1,4 @@
-package org.amnezia.awg;
+package pw.idrug.connections;
 
 import androidx.annotation.Nullable;
 

--- a/tunnel/src/main/java/org/amnezia/awg/backend/AwgQuickBackend.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/AwgQuickBackend.java
@@ -3,19 +3,19 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
 import android.content.Context;
 import android.util.Log;
 import android.util.Pair;
 
-import org.amnezia.awg.backend.BackendException.Reason;
-import org.amnezia.awg.backend.Tunnel.State;
-import org.amnezia.awg.util.RootShell;
-import org.amnezia.awg.util.ToolsInstaller;
-import org.amnezia.awg.config.Config;
-import org.amnezia.awg.crypto.Key;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.backend.BackendException.Reason;
+import pw.idrug.connections.backend.Tunnel.State;
+import pw.idrug.connections.util.RootShell;
+import pw.idrug.connections.util.ToolsInstaller;
+import pw.idrug.connections.config.Config;
+import pw.idrug.connections.crypto.Key;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -35,12 +35,12 @@ import androidx.annotation.Nullable;
 
 /**
  * Implementation of {@link Backend} that uses the kernel module and {@code awg-quick} to provide
- * AmneziaWG tunnels.
+ * iDrugConnections tunnels.
  */
 
 @NonNullForAll
 public final class AwgQuickBackend implements Backend {
-    private static final String TAG = "AmneziaWG/AwgQuickBackend";
+    private static final String TAG = "iDrugConnections/AwgQuickBackend";
     private final File localTemporaryDir;
     private final RootShell rootShell;
     private final Map<Tunnel, Config> runningConfigs = new HashMap<>();

--- a/tunnel/src/main/java/org/amnezia/awg/backend/Backend.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/Backend.java
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
-import org.amnezia.awg.config.Config;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.config.Config;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.Set;
 
 import androidx.annotation.Nullable;
 
 /**
- * Interface for implementations of the AmneziaWG secure network tunnel.
+ * Interface for implementations of the iDrugConnections secure network tunnel.
  */
 
 @NonNullForAll

--- a/tunnel/src/main/java/org/amnezia/awg/backend/BackendException.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/BackendException.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 /**
  * A subclass of {@link Exception} that encapsulates the reasons for a failure originating in

--- a/tunnel/src/main/java/org/amnezia/awg/backend/GoBackend.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/GoBackend.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
 import android.content.Context;
 import android.content.Intent;
@@ -12,16 +12,16 @@ import android.os.ParcelFileDescriptor;
 import android.system.OsConstants;
 import android.util.Log;
 
-import org.amnezia.awg.backend.BackendException.Reason;
-import org.amnezia.awg.backend.Tunnel.State;
-import org.amnezia.awg.util.SharedLibraryLoader;
-import org.amnezia.awg.config.Config;
-import org.amnezia.awg.config.InetEndpoint;
-import org.amnezia.awg.config.InetNetwork;
-import org.amnezia.awg.config.Peer;
-import org.amnezia.awg.crypto.Key;
-import org.amnezia.awg.crypto.KeyFormatException;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.backend.BackendException.Reason;
+import pw.idrug.connections.backend.Tunnel.State;
+import pw.idrug.connections.util.SharedLibraryLoader;
+import pw.idrug.connections.config.Config;
+import pw.idrug.connections.config.InetEndpoint;
+import pw.idrug.connections.config.InetNetwork;
+import pw.idrug.connections.config.Peer;
+import pw.idrug.connections.crypto.Key;
+import pw.idrug.connections.crypto.KeyFormatException;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.net.InetAddress;
 import java.util.Collections;
@@ -35,16 +35,16 @@ import java.util.concurrent.TimeoutException;
 import androidx.annotation.Nullable;
 import androidx.collection.ArraySet;
 
-import static org.amnezia.awg.GoBackend.*;
+import static pw.idrug.connections.GoBackend.*;
 
 /**
  * Implementation of {@link Backend} that uses the amneziawg-go userspace implementation to provide
- * AmneziaWG tunnels.
+ * iDrugConnections tunnels.
  */
 @NonNullForAll
 public final class GoBackend implements Backend {
     private static final int DNS_RESOLUTION_RETRIES = 10;
-    private static final String TAG = "AmneziaWG/GoBackend";
+    private static final String TAG = "iDrugConnections/GoBackend";
     @Nullable private static AlwaysOnCallback alwaysOnCallback;
     private static GhettoCompletableFuture<VpnService> vpnService = new GhettoCompletableFuture<>();
     private final Context context;

--- a/tunnel/src/main/java/org/amnezia/awg/backend/Statistics.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/Statistics.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
 import android.os.SystemClock;
 
-import org.amnezia.awg.crypto.Key;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.crypto.Key;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -30,12 +30,12 @@ public class Statistics {
     /**
      * Add a peer and its current stats to the internal map.
      *
-     * @param key               An AmneziaWG public key bound to a particular peer
-     * @param rxBytes           The received traffic for the {@link org.amnezia.config.Peer} referenced by
+     * @param key               An iDrugConnections public key bound to a particular peer
+     * @param rxBytes           The received traffic for the {@link pw.idrug.connections.config.Peer} referenced by
      *                          the provided {@link Key}. This value is in bytes
-     * @param txBytes           The transmitted traffic for the {@link org.amnezia.config.Peer} referenced by
+     * @param txBytes           The transmitted traffic for the {@link pw.idrug.connections.config.Peer} referenced by
      *                          the provided {@link Key}. This value is in bytes.
-     * @param latestHandshake   The timestamp of the latest handshake for the {@link org.amnezia.config.Peer}
+     * @param latestHandshake   The timestamp of the latest handshake for the {@link pw.idrug.connections.config.Peer}
      *                          referenced by the provided {@link Key}. The value is in epoch milliseconds.
      */
     void add(final Key key, final long rxBytes, final long txBytes, final long latestHandshake) {
@@ -53,9 +53,9 @@ public class Statistics {
     }
 
     /**
-     * Get the statistics for the {@link org.amnezia.config.Peer} referenced by the provided {@link Key}
+     * Get the statistics for the {@link pw.idrug.connections.config.Peer} referenced by the provided {@link Key}
      *
-     * @param peer A {@link Key} representing a {@link org.amnezia.config.Peer}.
+     * @param peer A {@link Key} representing a {@link pw.idrug.connections.config.Peer}.
      * @return a {@link PeerStats} representing various statistics about this peer.
      */
     @Nullable
@@ -66,8 +66,8 @@ public class Statistics {
     /**
      * Get the list of peers being tracked by this instance.
      *
-     * @return An array of {@link Key} instances representing AmneziaWG
-     * {@link org.amnezia.config.Peer}s
+     * @return An array of {@link Key} instances representing iDrugConnections
+     * {@link pw.idrug.connections.config.Peer}s
      */
     public Key[] peers() {
         return stats.keySet().toArray(new Key[0]);

--- a/tunnel/src/main/java/org/amnezia/awg/backend/Tunnel.java
+++ b/tunnel/src/main/java/org/amnezia/awg/backend/Tunnel.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.backend;
+package pw.idrug.connections.backend;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.regex.Pattern;
 
 /**
- * Represents an AmneziaWG tunnel.
+ * Represents an iDrugConnections tunnel.
  */
 
 @NonNullForAll

--- a/tunnel/src/main/java/org/amnezia/awg/config/Attribute.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Attribute.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.Iterator;
 import java.util.Optional;

--- a/tunnel/src/main/java/org/amnezia/awg/config/BadConfigException.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/BadConfigException.java
@@ -3,10 +3,10 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.crypto.KeyFormatException;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.crypto.KeyFormatException;
+import pw.idrug.connections.util.NonNullForAll;
 
 import androidx.annotation.Nullable;
 

--- a/tunnel/src/main/java/org/amnezia/awg/config/Config.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Config.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.config.BadConfigException.Location;
-import org.amnezia.awg.config.BadConfigException.Reason;
-import org.amnezia.awg.config.BadConfigException.Section;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.config.BadConfigException.Location;
+import pw.idrug.connections.config.BadConfigException.Reason;
+import pw.idrug.connections.config.BadConfigException.Section;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -44,7 +44,7 @@ public final class Config {
      * {@link BadConfigException} if the input is not well-formed or contains data that cannot
      * be parsed.
      *
-     * @param stream a stream of UTF-8 text that is interpreted as an AmneziaWG configuration
+     * @param stream a stream of UTF-8 text that is interpreted as an iDrugConnections configuration
      * @return a {@code Config} instance representing the supplied configuration
      */
     public static Config parse(final InputStream stream)
@@ -57,7 +57,7 @@ public final class Config {
      * {@link BadConfigException} if the input is not well-formed or contains data that cannot
      * be parsed.
      *
-     * @param reader a BufferedReader of UTF-8 text that is interpreted as an AmneziaWG configuration
+     * @param reader a BufferedReader of UTF-8 text that is interpreted as an iDrugConnections configuration
      * @return a {@code Config} instance representing the supplied configuration
      */
     public static Config parse(final BufferedReader reader)
@@ -169,7 +169,7 @@ public final class Config {
     }
 
     /**
-     * Serializes the {@code Config} for use with the AmneziaWG cross-platform userspace API.
+     * Serializes the {@code Config} for use with the iDrugConnections cross-platform userspace API.
      *
      * @return the {@code Config} represented as a series of "key=value" lines
      */

--- a/tunnel/src/main/java/org/amnezia/awg/config/InetAddresses.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/InetAddresses.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.lang.reflect.Method;
 import java.net.Inet4Address;

--- a/tunnel/src/main/java/org/amnezia/awg/config/InetEndpoint.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/InetEndpoint.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;
@@ -21,7 +21,7 @@ import androidx.annotation.Nullable;
 
 
 /**
- * An external endpoint (host and port) used to connect to an AmneziaWG {@link Peer}.
+ * An external endpoint (host and port) used to connect to an iDrugConnections {@link Peer}.
  * <p>
  * Instances of this class are externally immutable.
  */

--- a/tunnel/src/main/java/org/amnezia/awg/config/InetNetwork.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/InetNetwork.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.net.Inet4Address;
 import java.net.InetAddress;

--- a/tunnel/src/main/java/org/amnezia/awg/config/Interface.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Interface.java
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.config.BadConfigException.Location;
-import org.amnezia.awg.config.BadConfigException.Reason;
-import org.amnezia.awg.config.BadConfigException.Section;
-import org.amnezia.awg.crypto.Key;
-import org.amnezia.awg.crypto.KeyFormatException;
-import org.amnezia.awg.crypto.KeyPair;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.config.BadConfigException.Location;
+import pw.idrug.connections.config.BadConfigException.Reason;
+import pw.idrug.connections.config.BadConfigException.Section;
+import pw.idrug.connections.crypto.Key;
+import pw.idrug.connections.crypto.KeyFormatException;
+import pw.idrug.connections.crypto.KeyPair;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.net.InetAddress;
 import java.util.Collection;
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 import androidx.annotation.Nullable;
 
 /**
- * Represents the configuration for an AmneziaWG interface (an [Interface] block). Interfaces must
+ * Represents the configuration for an iDrugConnections interface (an [Interface] block). Interfaces must
  * have a private key (used to initialize a {@code KeyPair}), and may optionally have several other
  * attributes.
  * <p>
@@ -232,7 +232,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the UDP port number that the AmneziaWG interface will listen on.
+     * Returns the UDP port number that the iDrugConnections interface will listen on.
      *
      * @return a UDP port number, or {@code Optional.empty()} if none is configured
      */
@@ -241,7 +241,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the MTU used for the AmneziaWG interface.
+     * Returns the MTU used for the iDrugConnections interface.
      *
      * @return the MTU, or {@code Optional.empty()} if none is configured
      */
@@ -250,7 +250,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the junkPacketCount used for the AmneziaWG interface.
+     * Returns the junkPacketCount used for the iDrugConnections interface.
      *
      * @return the junkPacketCount, or {@code Optional.empty()} if none is configured
      */
@@ -259,7 +259,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the junkPacketMinSize used for the AmneziaWG interface.
+     * Returns the junkPacketMinSize used for the iDrugConnections interface.
      *
      * @return the junkPacketMinSize, or {@code Optional.empty()} if none is configured
      */
@@ -268,7 +268,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the junkPacketMaxSize used for the AmneziaWG interface.
+     * Returns the junkPacketMaxSize used for the iDrugConnections interface.
      *
      * @return the junkPacketMaxSize, or {@code Optional.empty()} if none is configured
      */
@@ -277,7 +277,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the initPacketJunkSize used for the AmneziaWG interface.
+     * Returns the initPacketJunkSize used for the iDrugConnections interface.
      *
      * @return the initPacketJunkSize, or {@code Optional.empty()} if none is configured
      */
@@ -286,7 +286,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the responsePacketJunkSize used for the AmneziaWG interface.
+     * Returns the responsePacketJunkSize used for the iDrugConnections interface.
      *
      * @return the responsePacketJunkSize, or {@code Optional.empty()} if none is configured
      */
@@ -295,7 +295,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the initPacketMagicHeader used for the AmneziaWG interface.
+     * Returns the initPacketMagicHeader used for the iDrugConnections interface.
      *
      * @return the initPacketMagicHeader, or {@code Optional.empty()} if none is configured
      */
@@ -304,7 +304,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the responsePacketMagicHeader used for the AmneziaWG interface.
+     * Returns the responsePacketMagicHeader used for the iDrugConnections interface.
      *
      * @return the responsePacketMagicHeader, or {@code Optional.empty()} if none is configured
      */
@@ -313,7 +313,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the underloadPacketMagicHeader used for the AmneziaWG interface.
+     * Returns the underloadPacketMagicHeader used for the iDrugConnections interface.
      *
      * @return the underloadPacketMagicHeader, or {@code Optional.empty()} if none is configured
      */
@@ -322,7 +322,7 @@ public final class Interface {
     }
 
     /**
-     * Returns the transportPacketMagicHeader used for the AmneziaWG interface.
+     * Returns the transportPacketMagicHeader used for the iDrugConnections interface.
      *
      * @return the transportPacketMagicHeader, or {@code Optional.empty()} if none is configured
      */
@@ -403,7 +403,7 @@ public final class Interface {
     }
 
     /**
-     * Serializes the {@code Interface} for use with the AmneziaWG cross-platform userspace API.
+     * Serializes the {@code Interface} for use with the iDrugConnections cross-platform userspace API.
      * Note that not all attributes are included in this representation.
      *
      * @return the {@code Interface} represented as a series of "KEY=VALUE" lines

--- a/tunnel/src/main/java/org/amnezia/awg/config/ParseException.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/ParseException.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import androidx.annotation.Nullable;
 

--- a/tunnel/src/main/java/org/amnezia/awg/config/Peer.java
+++ b/tunnel/src/main/java/org/amnezia/awg/config/Peer.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.config.BadConfigException.Location;
-import org.amnezia.awg.config.BadConfigException.Reason;
-import org.amnezia.awg.config.BadConfigException.Section;
-import org.amnezia.awg.crypto.Key;
-import org.amnezia.awg.crypto.KeyFormatException;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.config.BadConfigException.Location;
+import pw.idrug.connections.config.BadConfigException.Reason;
+import pw.idrug.connections.config.BadConfigException.Section;
+import pw.idrug.connections.crypto.Key;
+import pw.idrug.connections.crypto.KeyFormatException;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -23,7 +23,7 @@ import java.util.Set;
 import androidx.annotation.Nullable;
 
 /**
- * Represents the configuration for an AmneziaWG peer (a [Peer] block). Peers must have a public key,
+ * Represents the configuration for an iDrugConnections peer (a [Peer] block). Peers must have a public key,
  * and may optionally have several other attributes.
  * <p>
  * Instances of this class are immutable.
@@ -185,7 +185,7 @@ public final class Peer {
     }
 
     /**
-     * Serializes the {@code Peer} for use with the AmneziaWG cross-platform userspace API. Note
+     * Serializes the {@code Peer} for use with the iDrugConnections cross-platform userspace API. Note
      * that not all attributes are included in this representation.
      *
      * @return the {@code Peer} represented as a series of "key=value" lines

--- a/tunnel/src/main/java/org/amnezia/awg/crypto/Curve25519.java
+++ b/tunnel/src/main/java/org/amnezia/awg/crypto/Curve25519.java
@@ -4,9 +4,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.crypto;
+package pw.idrug.connections.crypto;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.util.Arrays;
 
@@ -15,7 +15,7 @@ import androidx.annotation.Nullable;
 /**
  * Implementation of Curve25519 ECDH.
  * <p>
- * This implementation was imported to AmneziaWG from noise-java:
+ * This implementation was imported to iDrugConnections from noise-java:
  * https://github.com/rweather/noise-java
  * <p>
  * This implementation is based on that from arduinolibs:

--- a/tunnel/src/main/java/org/amnezia/awg/crypto/Key.java
+++ b/tunnel/src/main/java/org/amnezia/awg/crypto/Key.java
@@ -3,17 +3,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.crypto;
+package pw.idrug.connections.crypto;
 
-import org.amnezia.awg.crypto.KeyFormatException.Type;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.crypto.KeyFormatException.Type;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
 
 /**
- * Represents an AmneziaWG public or private key. This class uses specialized constant-time base64
+ * Represents an iDrugConnections public or private key. This class uses specialized constant-time base64
  * and hexadecimal codec implementations that resist side-channel attacks.
  * <p>
  * Instances of this class are immutable.
@@ -83,10 +83,10 @@ public final class Key {
     }
 
     /**
-     * Decodes an AmneziaWG public or private key from its base64 string representation. This
+     * Decodes an iDrugConnections public or private key from its base64 string representation. This
      * function throws a {@link KeyFormatException} if the source string is not well-formed.
      *
-     * @param str the base64 string representation of an AmneziaWG key
+     * @param str the base64 string representation of an iDrugConnections key
      * @return the decoded key encapsulated in an immutable container
      */
     public static Key fromBase64(final String str) throws KeyFormatException {
@@ -120,10 +120,10 @@ public final class Key {
     }
 
     /**
-     * Wraps an AmneziaWG public or private key in an immutable container. This function throws a
+     * Wraps an iDrugConnections public or private key in an immutable container. This function throws a
      * {@link KeyFormatException} if the source data is not the correct length.
      *
-     * @param bytes an array of bytes containing an AmneziaWG key in binary format
+     * @param bytes an array of bytes containing an iDrugConnections key in binary format
      * @return the key encapsulated in an immutable container
      */
     public static Key fromBytes(final byte[] bytes) throws KeyFormatException {
@@ -133,10 +133,10 @@ public final class Key {
     }
 
     /**
-     * Decodes an AmneziaWG public or private key from its hexadecimal string representation. This
+     * Decodes an iDrugConnections public or private key from its hexadecimal string representation. This
      * function throws a {@link KeyFormatException} if the source string is not well-formed.
      *
-     * @param str the hexadecimal string representation of an AmneziaWG key
+     * @param str the hexadecimal string representation of an iDrugConnections key
      * @return the decoded key encapsulated in an immutable container
      */
     public static Key fromHex(final String str) throws KeyFormatException {
@@ -269,7 +269,7 @@ public final class Key {
     }
 
     /**
-     * The supported formats for encoding an AmneziaWG key.
+     * The supported formats for encoding an iDrugConnections key.
      */
     public enum Format {
         BASE64(44),

--- a/tunnel/src/main/java/org/amnezia/awg/crypto/KeyFormatException.java
+++ b/tunnel/src/main/java/org/amnezia/awg/crypto/KeyFormatException.java
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.crypto;
+package pw.idrug.connections.crypto;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 /**
  * An exception thrown when attempting to parse an invalid key (too short, too long, or byte

--- a/tunnel/src/main/java/org/amnezia/awg/crypto/KeyPair.java
+++ b/tunnel/src/main/java/org/amnezia/awg/crypto/KeyPair.java
@@ -3,12 +3,12 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.crypto;
+package pw.idrug.connections.crypto;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 /**
- * Represents a Curve25519 key pair as used by AmneziaWG.
+ * Represents a Curve25519 key pair as used by iDrugConnections.
  * <p>
  * Instances of this class are immutable.
  */

--- a/tunnel/src/main/java/org/amnezia/awg/util/NonNullForAll.java
+++ b/tunnel/src/main/java/org/amnezia/awg/util/NonNullForAll.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util;
+package pw.idrug.connections.util;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/tunnel/src/main/java/org/amnezia/awg/util/RootShell.java
+++ b/tunnel/src/main/java/org/amnezia/awg/util/RootShell.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util;
+package pw.idrug.connections.util;
 
 import android.content.Context;
 import android.util.Log;
 
-import org.amnezia.awg.util.RootShell.RootShellException.Reason;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.RootShell.RootShellException.Reason;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -29,7 +29,7 @@ import androidx.annotation.Nullable;
 @NonNullForAll
 public class RootShell {
     private static final String SU = "su";
-    private static final String TAG = "AmneziaWG/RootShell";
+    private static final String TAG = "iDrugConnections/RootShell";
 
     private final File localBinaryDir;
     private final File localTemporaryDir;

--- a/tunnel/src/main/java/org/amnezia/awg/util/SharedLibraryLoader.java
+++ b/tunnel/src/main/java/org/amnezia/awg/util/SharedLibraryLoader.java
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util;
+package pw.idrug.connections.util;
 
 import android.content.Context;
 import android.os.Build;
 import android.util.Log;
 
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.io.File;
 import java.io.FileOutputStream;
@@ -27,7 +27,7 @@ import androidx.annotation.RestrictTo.Scope;
 @NonNullForAll
 @RestrictTo(Scope.LIBRARY_GROUP)
 public final class SharedLibraryLoader {
-    private static final String TAG = "AmneziaWG/SharedLibraryLoader";
+    private static final String TAG = "iDrugConnections/SharedLibraryLoader";
 
     private SharedLibraryLoader() {
     }

--- a/tunnel/src/main/java/org/amnezia/awg/util/ToolsInstaller.java
+++ b/tunnel/src/main/java/org/amnezia/awg/util/ToolsInstaller.java
@@ -3,14 +3,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util;
+package pw.idrug.connections.util;
 
 import android.content.Context;
 import android.system.OsConstants;
 import android.util.Log;
 
-import org.amnezia.awg.util.RootShell.RootShellException;
-import org.amnezia.awg.util.NonNullForAll;
+import pw.idrug.connections.util.RootShell.RootShellException;
+import pw.idrug.connections.util.NonNullForAll;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -23,7 +23,7 @@ import androidx.annotation.RestrictTo;
 import androidx.annotation.RestrictTo.Scope;
 
 /**
- * Helper to install AmneziaWG tools to the system partition.
+ * Helper to install iDrugConnections tools to the system partition.
  */
 
 @NonNullForAll
@@ -39,7 +39,7 @@ public final class ToolsInstaller {
             new File("/system/bin"),
     };
     @Nullable private static final File INSTALL_DIR = getInstallDir();
-    private static final String TAG = "AmneziaWG/ToolsInstaller";
+    private static final String TAG = "iDrugConnections/ToolsInstaller";
 
     private final Context context;
     private final File localBinaryDir;
@@ -134,8 +134,8 @@ public final class ToolsInstaller {
 
     @RestrictTo(Scope.LIBRARY_GROUP)
     public int install() throws RootShellException, IOException {
-        if (!context.getPackageName().startsWith("org.amnezia."))
-            throw new SecurityException("The tools may only be installed system-wide from the main AmneziaWG app.");
+        if (!context.getPackageName().startsWith("pw.idrug.connections."))
+            throw new SecurityException("The tools may only be installed system-wide from the main iDrugConnections app.");
         return willInstallAsMagiskModule() ? installMagisk() : installSystem();
     }
 
@@ -145,7 +145,7 @@ public final class ToolsInstaller {
 
         script.append("trap 'rm -rf /data/adb/modules/amneziawg' INT TERM EXIT; ");
         script.append(String.format("rm -rf /data/adb/modules/amneziawg/; mkdir -p /data/adb/modules/amneziawg%s; ", INSTALL_DIR));
-        script.append("printf 'id=amneziawg\nname=AmneziaWG Command Line Tools\nversion=1.0\nversionCode=1\nauthor=amnezia\ndescription=Command line tools for AmneziaWG\nminMagisk=1500\n' > /data/adb/modules/amneziawg/module.prop; ");
+        script.append("printf 'id=amneziawg\nname=iDrugConnections Command Line Tools\nversion=1.0\nversionCode=1\nauthor=amnezia\ndescription=Command line tools for iDrugConnections\nminMagisk=1500\n' > /data/adb/modules/amneziawg/module.prop; ");
         script.append("touch /data/adb/modules/amneziawg/auto_mount; ");
         for (final String name : EXECUTABLES) {
             final File destination = new File("/data/adb/modules/amneziawg" + INSTALL_DIR, name);

--- a/tunnel/src/test/java/org/amnezia/awg/config/BadConfigExceptionTest.java
+++ b/tunnel/src/test/java/org/amnezia/awg/config/BadConfigExceptionTest.java
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
-import org.amnezia.awg.config.BadConfigException.Location;
-import org.amnezia.awg.config.BadConfigException.Reason;
-import org.amnezia.awg.config.BadConfigException.Section;
+import pw.idrug.connections.config.BadConfigException.Location;
+import pw.idrug.connections.config.BadConfigException.Reason;
+import pw.idrug.connections.config.BadConfigException.Section;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;

--- a/tunnel/src/test/java/org/amnezia/awg/config/ConfigTest.java
+++ b/tunnel/src/test/java/org/amnezia/awg/config/ConfigTest.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.config;
+package pw.idrug.connections.config;
 
 import org.junit.Test;
 

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -141,9 +141,9 @@
             android:exported="true"
             android:permission="${applicationId}.permission.CONTROL_TUNNELS">
             <intent-filter>
-                <action android:name="org.amnezia.awg.action.REFRESH_TUNNEL_STATES" />
-                <action android:name="org.amnezia.awg.action.SET_TUNNEL_UP" />
-                <action android:name="org.amnezia.awg.action.SET_TUNNEL_DOWN" />
+                <action android:name="pw.idrug.connections.action.REFRESH_TUNNEL_STATES" />
+                <action android:name="pw.idrug.connections.action.SET_TUNNEL_UP" />
+                <action android:name="pw.idrug.connections.action.SET_TUNNEL_DOWN" />
             </intent-filter>
         </receiver>
 

--- a/ui/src/main/java/org/amnezia/awg/Application.kt
+++ b/ui/src/main/java/org/amnezia/awg/Application.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg
+package pw.idrug.connections
 
 import android.content.Context
 import android.content.Intent
@@ -17,15 +17,15 @@ import androidx.datastore.preferences.core.PreferenceDataStoreFactory
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStoreFile
 import com.google.android.material.color.DynamicColors
-import org.amnezia.awg.backend.Backend
-import org.amnezia.awg.backend.GoBackend
-import org.amnezia.awg.backend.AwgQuickBackend
-import org.amnezia.awg.configStore.FileConfigStore
-import org.amnezia.awg.model.TunnelManager
-import org.amnezia.awg.util.RootShell
-import org.amnezia.awg.util.ToolsInstaller
-import org.amnezia.awg.util.UserKnobs
-import org.amnezia.awg.util.applicationScope
+import pw.idrug.connections.backend.Backend
+import pw.idrug.connections.backend.GoBackend
+import pw.idrug.connections.backend.AwgQuickBackend
+import pw.idrug.connections.configStore.FileConfigStore
+import pw.idrug.connections.model.TunnelManager
+import pw.idrug.connections.util.RootShell
+import pw.idrug.connections.util.ToolsInstaller
+import pw.idrug.connections.util.UserKnobs
+import pw.idrug.connections.util.applicationScope
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -128,8 +128,8 @@ class Application : android.app.Application() {
     }
 
     companion object {
-        val USER_AGENT = String.format(Locale.ENGLISH, "AmneziaWG/%s (Android %d; %s; %s; %s %s; %s)", BuildConfig.VERSION_NAME, Build.VERSION.SDK_INT, if (Build.SUPPORTED_ABIS.isNotEmpty()) Build.SUPPORTED_ABIS[0] else "unknown ABI", Build.BOARD, Build.MANUFACTURER, Build.MODEL, Build.FINGERPRINT)
-        private const val TAG = "AmneziaWG/Application"
+        val USER_AGENT = String.format(Locale.ENGLISH, "iDrugConnections/%s (Android %d; %s; %s; %s %s; %s)", BuildConfig.VERSION_NAME, Build.VERSION.SDK_INT, if (Build.SUPPORTED_ABIS.isNotEmpty()) Build.SUPPORTED_ABIS[0] else "unknown ABI", Build.BOARD, Build.MANUFACTURER, Build.MODEL, Build.FINGERPRINT)
+        private const val TAG = "iDrugConnections/Application"
         private lateinit var weakSelf: WeakReference<Application>
 
         fun get(): Application {

--- a/ui/src/main/java/org/amnezia/awg/BootShutdownReceiver.kt
+++ b/ui/src/main/java/org/amnezia/awg/BootShutdownReceiver.kt
@@ -2,14 +2,14 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg
+package pw.idrug.connections
 
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
-import org.amnezia.awg.backend.AwgQuickBackend
-import org.amnezia.awg.util.applicationScope
+import pw.idrug.connections.backend.AwgQuickBackend
+import pw.idrug.connections.util.applicationScope
 import kotlinx.coroutines.launch
 
 class BootShutdownReceiver : BroadcastReceiver() {
@@ -29,6 +29,6 @@ class BootShutdownReceiver : BroadcastReceiver() {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/BootShutdownReceiver"
+        private const val TAG = "iDrugConnections/BootShutdownReceiver"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/QuickTileService.kt
+++ b/ui/src/main/java/org/amnezia/awg/QuickTileService.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg
+package pw.idrug.connections
 
 import android.app.PendingIntent
 import android.content.Intent
@@ -19,12 +19,12 @@ import android.util.Log
 import androidx.annotation.RequiresApi
 import androidx.databinding.Observable
 import androidx.databinding.Observable.OnPropertyChangedCallback
-import org.amnezia.awg.activity.MainActivity
-import org.amnezia.awg.activity.TunnelToggleActivity
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.util.applicationScope
-import org.amnezia.awg.widget.SlashDrawable
+import pw.idrug.connections.activity.MainActivity
+import pw.idrug.connections.activity.TunnelToggleActivity
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.util.applicationScope
+import pw.idrug.connections.widget.SlashDrawable
 import kotlinx.coroutines.launch
 
 /**
@@ -180,7 +180,7 @@ class QuickTileService : TileService() {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/QuickTileService"
+        private const val TAG = "iDrugConnections/QuickTileService"
         var isAdded: Boolean = false
             private set
     }

--- a/ui/src/main/java/org/amnezia/awg/activity/BaseActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/BaseActivity.kt
@@ -2,15 +2,15 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.CallbackRegistry
 import androidx.databinding.CallbackRegistry.NotifierCallback
 import androidx.lifecycle.lifecycleScope
-import org.amnezia.awg.Application
-import org.amnezia.awg.model.ObservableTunnel
+import pw.idrug.connections.Application
+import pw.idrug.connections.model.ObservableTunnel
 import kotlinx.coroutines.launch
 
 /**

--- a/ui/src/main/java/org/amnezia/awg/activity/LogViewerActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/LogViewerActivity.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.content.ClipDescription.compareMimeTypes
 import android.content.ContentProvider
@@ -36,13 +36,13 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textview.MaterialTextView
-import org.amnezia.awg.BuildConfig
-import org.amnezia.awg.R
-import org.amnezia.awg.databinding.LogViewerActivityBinding
-import org.amnezia.awg.util.DownloadsFileSaver
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.resolveAttribute
-import org.amnezia.awg.crypto.KeyPair
+import pw.idrug.connections.BuildConfig
+import pw.idrug.connections.R
+import pw.idrug.connections.databinding.LogViewerActivityBinding
+import pw.idrug.connections.util.DownloadsFileSaver
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.resolveAttribute
+import pw.idrug.connections.crypto.KeyPair
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -294,7 +294,7 @@ class LogViewerActivity : AppCompatActivity() {
         private val THREADTIME_LINE: Pattern =
             Pattern.compile("^(\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3})(?:\\s+[0-9A-Za-z]+)?\\s+(\\d+)\\s+(\\d+)\\s+([A-Z])\\s+(.+?)\\s*: (.*)$")
         private val LOGS: MutableMap<String, ByteArray> = ConcurrentHashMap()
-        private const val TAG = "AmneziaWG/LogViewerActivity"
+        private const val TAG = "iDrugConnections/LogViewerActivity"
     }
 
     private inner class LogEntryAdapter : RecyclerView.Adapter<LogEntryAdapter.ViewHolder>() {

--- a/ui/src/main/java/org/amnezia/awg/activity/MainActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/MainActivity.kt
@@ -1,4 +1,4 @@
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.content.Intent
 import android.os.Bundle
@@ -12,17 +12,17 @@ import androidx.fragment.app.FragmentManager
 import androidx.fragment.app.FragmentTransaction
 import androidx.fragment.app.commit
 import com.google.android.material.bottomnavigation.BottomNavigationView
-import org.amnezia.awg.R
-import org.amnezia.awg.fragment.TunnelDetailFragment
-import org.amnezia.awg.fragment.TunnelEditorFragment
-import org.amnezia.awg.fragment.TunnelListFragment
-import org.amnezia.awg.fragment.AccountFragment
-import org.amnezia.awg.model.ObservableTunnel
+import pw.idrug.connections.R
+import pw.idrug.connections.fragment.TunnelDetailFragment
+import pw.idrug.connections.fragment.TunnelEditorFragment
+import pw.idrug.connections.fragment.TunnelListFragment
+import pw.idrug.connections.fragment.AccountFragment
+import pw.idrug.connections.model.ObservableTunnel
 
 /**
- * CRUD interface for AmneziaWG tunnels. This activity serves as the main entry point to the
- * AmneziaWG application, and contains several fragments for listing, viewing details of, and
- * editing the configuration and interface state of AmneziaWG tunnels.
+ * CRUD interface for iDrugConnections tunnels. This activity serves as the main entry point to the
+ * iDrugConnections application, and contains several fragments for listing, viewing details of, and
+ * editing the configuration and interface state of iDrugConnections tunnels.
  */
 class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener {
     private var actionBar: ActionBar? = null

--- a/ui/src/main/java/org/amnezia/awg/activity/SettingsActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/SettingsActivity.kt
@@ -1,4 +1,4 @@
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.app.DownloadManager
 import android.content.*
@@ -15,12 +15,12 @@ import androidx.fragment.app.commit
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
 import androidx.preference.PreferenceFragmentCompat
-import org.amnezia.awg.Application
-import org.amnezia.awg.QuickTileService
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.AwgQuickBackend
-import org.amnezia.awg.preference.PreferencesPreferenceDataStore
-import org.amnezia.awg.util.AdminKnobs
+import pw.idrug.connections.Application
+import pw.idrug.connections.QuickTileService
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.AwgQuickBackend
+import pw.idrug.connections.preference.PreferencesPreferenceDataStore
+import pw.idrug.connections.util.AdminKnobs
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/ui/src/main/java/org/amnezia/awg/activity/TunnelCreatorActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/TunnelCreatorActivity.kt
@@ -2,12 +2,12 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.os.Bundle
 import androidx.fragment.app.commit
-import org.amnezia.awg.fragment.TunnelEditorFragment
-import org.amnezia.awg.model.ObservableTunnel
+import pw.idrug.connections.fragment.TunnelEditorFragment
+import pw.idrug.connections.model.ObservableTunnel
 
 /**
  * Standalone activity for creating tunnels.

--- a/ui/src/main/java/org/amnezia/awg/activity/TunnelToggleActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/TunnelToggleActivity.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.content.ComponentName
 import android.os.Bundle
@@ -12,12 +12,12 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
-import org.amnezia.awg.Application
-import org.amnezia.awg.QuickTileService
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.GoBackend
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.util.ErrorMessages
+import pw.idrug.connections.Application
+import pw.idrug.connections.QuickTileService
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.GoBackend
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.util.ErrorMessages
 import kotlinx.coroutines.launch
 
 class TunnelToggleActivity : AppCompatActivity() {
@@ -58,6 +58,6 @@ class TunnelToggleActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/TunnelToggleActivity"
+        private const val TAG = "iDrugConnections/TunnelToggleActivity"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/activity/TvMainActivity.kt
+++ b/ui/src/main/java/org/amnezia/awg/activity/TvMainActivity.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.activity
+package pw.idrug.connections.activity
 
 import android.Manifest
 import android.content.ActivityNotFoundException
@@ -34,22 +34,22 @@ import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.GridLayoutManager.SpanSizeLookup
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.GoBackend
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.databinding.Keyed
-import org.amnezia.awg.databinding.ObservableKeyedArrayList
-import org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter
-import org.amnezia.awg.databinding.TvActivityBinding
-import org.amnezia.awg.databinding.TvFileListItemBinding
-import org.amnezia.awg.databinding.TvTunnelListItemBinding
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.QuantityFormatter
-import org.amnezia.awg.util.TunnelImporter
-import org.amnezia.awg.util.UserKnobs
-import org.amnezia.awg.util.applicationScope
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.GoBackend
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.databinding.Keyed
+import pw.idrug.connections.databinding.ObservableKeyedArrayList
+import pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter
+import pw.idrug.connections.databinding.TvActivityBinding
+import pw.idrug.connections.databinding.TvFileListItemBinding
+import pw.idrug.connections.databinding.TvTunnelListItemBinding
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.QuantityFormatter
+import pw.idrug.connections.util.TunnelImporter
+import pw.idrug.connections.util.UserKnobs
+import pw.idrug.connections.util.applicationScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -423,6 +423,6 @@ class TvMainActivity : AppCompatActivity() {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/TvMainActivity"
+        private const val TAG = "iDrugConnections/TvMainActivity"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/configStore/ConfigStore.kt
+++ b/ui/src/main/java/org/amnezia/awg/configStore/ConfigStore.kt
@@ -2,12 +2,12 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.configStore
+package pw.idrug.connections.configStore
 
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.config.Config
 
 /**
- * Interface for persistent storage providers for AmneziaWG configurations.
+ * Interface for persistent storage providers for iDrugConnections configurations.
  */
 interface ConfigStore {
     /**

--- a/ui/src/main/java/org/amnezia/awg/configStore/FileConfigStore.kt
+++ b/ui/src/main/java/org/amnezia/awg/configStore/FileConfigStore.kt
@@ -2,13 +2,13 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.configStore
+package pw.idrug.connections.configStore
 
 import android.content.Context
 import android.util.Log
-import org.amnezia.awg.R
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.R
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.Config
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileNotFoundException
@@ -77,6 +77,6 @@ class FileConfigStore(private val context: Context) : ConfigStore {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/FileConfigStore"
+        private const val TAG = "iDrugConnections/FileConfigStore"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/databinding/BindingAdapters.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/BindingAdapters.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 import android.text.InputFilter
 import android.view.LayoutInflater
@@ -18,14 +18,14 @@ import androidx.databinding.adapters.ListenerUtil
 import androidx.fragment.app.Fragment
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import org.amnezia.awg.BR
-import org.amnezia.awg.R
-import org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler
-import org.amnezia.awg.widget.ToggleSwitch
-import org.amnezia.awg.widget.ToggleSwitch.OnBeforeCheckedChangeListener
-import org.amnezia.awg.widget.TvCardView
-import org.amnezia.awg.config.Attribute
-import org.amnezia.awg.config.InetNetwork
+import pw.idrug.connections.BR
+import pw.idrug.connections.R
+import pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler
+import pw.idrug.connections.widget.ToggleSwitch
+import pw.idrug.connections.widget.ToggleSwitch.OnBeforeCheckedChangeListener
+import pw.idrug.connections.widget.TvCardView
+import pw.idrug.connections.config.Attribute
+import pw.idrug.connections.config.InetNetwork
 import java.net.InetAddress
 import java.util.Optional
 

--- a/ui/src/main/java/org/amnezia/awg/databinding/ItemChangeListener.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/ItemChangeListener.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 import android.view.LayoutInflater
 import android.view.View
@@ -11,7 +11,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ObservableList
 import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
-import org.amnezia.awg.BR
+import pw.idrug.connections.BR
 import java.lang.ref.WeakReference
 
 /**

--- a/ui/src/main/java/org/amnezia/awg/databinding/Keyed.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/Keyed.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 /**
  * Interface for objects that have a identifying key of the given type.

--- a/ui/src/main/java/org/amnezia/awg/databinding/ObservableKeyedArrayList.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/ObservableKeyedArrayList.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 import androidx.databinding.ObservableArrayList
 

--- a/ui/src/main/java/org/amnezia/awg/databinding/ObservableKeyedRecyclerViewAdapter.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/ObservableKeyedRecyclerViewAdapter.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 import android.content.Context
 import android.view.LayoutInflater
@@ -11,7 +11,7 @@ import androidx.databinding.DataBindingUtil
 import androidx.databinding.ObservableList
 import androidx.databinding.ViewDataBinding
 import androidx.recyclerview.widget.RecyclerView
-import org.amnezia.awg.BR
+import pw.idrug.connections.BR
 import java.lang.ref.WeakReference
 
 /**

--- a/ui/src/main/java/org/amnezia/awg/databinding/ObservableSortedKeyedArrayList.kt
+++ b/ui/src/main/java/org/amnezia/awg/databinding/ObservableSortedKeyedArrayList.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.databinding
+package pw.idrug.connections.databinding
 
 import java.util.AbstractList
 import java.util.Collections

--- a/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AccountFragment.kt
@@ -1,4 +1,4 @@
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.content.Context
 import android.content.Intent
@@ -17,9 +17,9 @@ import com.squareup.picasso.Picasso
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
 import okhttp3.*
-import org.amnezia.awg.R
-import org.amnezia.awg.Application
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.R
+import pw.idrug.connections.Application
+import pw.idrug.connections.config.Config
 import org.json.JSONArray
 import org.json.JSONObject
 import java.io.File

--- a/ui/src/main/java/org/amnezia/awg/fragment/AddTunnelsSheet.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AddTunnelsSheet.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.content.pm.PackageManager
 import android.graphics.drawable.GradientDrawable
@@ -19,8 +19,8 @@ import androidx.fragment.app.setFragmentResult
 import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
-import org.amnezia.awg.R
-import org.amnezia.awg.util.resolveAttribute
+import pw.idrug.connections.R
+import pw.idrug.connections.util.resolveAttribute
 
 class AddTunnelsSheet : BottomSheetDialogFragment() {
 

--- a/ui/src/main/java/org/amnezia/awg/fragment/AppListDialogFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AppListDialogFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.Manifest
 import android.app.Dialog
@@ -21,12 +21,12 @@ import androidx.fragment.app.setFragmentResult
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.google.android.material.tabs.TabLayout
-import org.amnezia.awg.BR
-import org.amnezia.awg.R
-import org.amnezia.awg.databinding.AppListDialogFragmentBinding
-import org.amnezia.awg.databinding.ObservableKeyedArrayList
-import org.amnezia.awg.model.ApplicationData
-import org.amnezia.awg.util.ErrorMessages
+import pw.idrug.connections.BR
+import pw.idrug.connections.R
+import pw.idrug.connections.databinding.AppListDialogFragmentBinding
+import pw.idrug.connections.databinding.ObservableKeyedArrayList
+import pw.idrug.connections.model.ApplicationData
+import pw.idrug.connections.util.ErrorMessages
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/ui/src/main/java/org/amnezia/awg/fragment/BaseFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/BaseFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.content.Context
 import android.util.Log
@@ -14,16 +14,16 @@ import androidx.databinding.ViewDataBinding
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.activity.BaseActivity
-import org.amnezia.awg.activity.BaseActivity.OnSelectedTunnelChangedListener
-import org.amnezia.awg.backend.GoBackend
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.databinding.TunnelDetailFragmentBinding
-import org.amnezia.awg.databinding.TunnelListItemBinding
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.util.ErrorMessages
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.activity.BaseActivity
+import pw.idrug.connections.activity.BaseActivity.OnSelectedTunnelChangedListener
+import pw.idrug.connections.backend.GoBackend
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.databinding.TunnelDetailFragmentBinding
+import pw.idrug.connections.databinding.TunnelListItemBinding
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.util.ErrorMessages
 import kotlinx.coroutines.launch
 
 /**
@@ -109,6 +109,6 @@ abstract class BaseFragment : Fragment(), OnSelectedTunnelChangedListener {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/BaseFragment"
+        private const val TAG = "iDrugConnections/BaseFragment"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/fragment/ConfigNamingDialogFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/ConfigNamingDialogFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.app.Dialog
 import android.os.Bundle
@@ -10,11 +10,11 @@ import android.view.WindowManager
 import androidx.fragment.app.DialogFragment
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.databinding.ConfigNamingDialogFragmentBinding
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.databinding.ConfigNamingDialogFragmentBinding
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.Config
 import kotlinx.coroutines.launch
 import java.io.ByteArrayInputStream
 import java.io.IOException

--- a/ui/src/main/java/org/amnezia/awg/fragment/TunnelDetailFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/TunnelDetailFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -15,12 +15,12 @@ import androidx.core.view.MenuProvider
 import androidx.databinding.DataBindingUtil
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.databinding.TunnelDetailFragmentBinding
-import org.amnezia.awg.databinding.TunnelDetailPeerBinding
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.util.QuantityFormatter
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.databinding.TunnelDetailFragmentBinding
+import pw.idrug.connections.databinding.TunnelDetailPeerBinding
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.util.QuantityFormatter
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 

--- a/ui/src/main/java/org/amnezia/awg/fragment/TunnelEditorFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/TunnelEditorFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.content.Context
 import android.os.Bundle
@@ -23,20 +23,20 @@ import androidx.core.view.MenuProvider
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.databinding.TunnelEditorFragmentBinding
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.util.AdminKnobs
-import org.amnezia.awg.util.BiometricAuthenticator
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.viewmodel.ConfigProxy
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.databinding.TunnelEditorFragmentBinding
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.util.AdminKnobs
+import pw.idrug.connections.util.BiometricAuthenticator
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.viewmodel.ConfigProxy
+import pw.idrug.connections.config.Config
 import kotlinx.coroutines.launch
 
 /**
- * Fragment for editing an AmneziaWG configuration.
+ * Fragment for editing an iDrugConnections configuration.
  */
 class TunnelEditorFragment : BaseFragment(), MenuProvider {
     private var haveShownKeys = false
@@ -339,6 +339,6 @@ class TunnelEditorFragment : BaseFragment(), MenuProvider {
         private const val KEY_LOCAL_CONFIG = "local_config"
         private const val KEY_ORIGINAL_NAME = "original_name"
         const val ARG_AUTO_SHOW_APP_SELECTOR = "auto_show_app_selector"
-        private const val TAG = "AmneziaWG/TunnelEditorFragment"
+        private const val TAG = "iDrugConnections/TunnelEditorFragment"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/fragment/TunnelListFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/TunnelListFragment.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.fragment
+package pw.idrug.connections.fragment
 
 import android.content.Intent
 import android.content.res.Resources
@@ -26,27 +26,27 @@ import com.google.android.material.snackbar.Snackbar
 import com.google.zxing.qrcode.QRCodeReader
 import com.journeyapps.barcodescanner.ScanContract
 import com.journeyapps.barcodescanner.ScanOptions
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.activity.TunnelCreatorActivity
-import org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler
-import org.amnezia.awg.databinding.TunnelListFragmentBinding
-import org.amnezia.awg.databinding.TunnelListItemBinding
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.activity.MainActivity
-import org.amnezia.awg.viewmodel.ConfigProxy
-import org.amnezia.awg.fragment.AppListDialogFragment
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.QrCodeFromFileScanner
-import org.amnezia.awg.util.TunnelImporter
-import org.amnezia.awg.widget.MultiselectableRelativeLayout
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.activity.TunnelCreatorActivity
+import pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler
+import pw.idrug.connections.databinding.TunnelListFragmentBinding
+import pw.idrug.connections.databinding.TunnelListItemBinding
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.activity.MainActivity
+import pw.idrug.connections.viewmodel.ConfigProxy
+import pw.idrug.connections.fragment.AppListDialogFragment
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.QrCodeFromFileScanner
+import pw.idrug.connections.util.TunnelImporter
+import pw.idrug.connections.widget.MultiselectableRelativeLayout
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 
 /**
- * Fragment containing a list of known AmneziaWG tunnels. It allows creating and deleting tunnels.
+ * Fragment containing a list of known iDrugConnections tunnels. It allows creating and deleting tunnels.
  */
 class TunnelListFragment : BaseFragment() {
     private val actionModeListener = ActionModeListener()
@@ -397,6 +397,6 @@ class TunnelListFragment : BaseFragment() {
     companion object {
         private const val CHECKED_ITEMS = "CHECKED_ITEMS"
         const val ARG_OPEN_TUNNEL_FOR_APPS = "open_tunnel_for_apps"
-        private const val TAG = "AmneziaWG/TunnelListFragment"
+        private const val TAG = "iDrugConnections/TunnelListFragment"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/model/ApplicationData.kt
+++ b/ui/src/main/java/org/amnezia/awg/model/ApplicationData.kt
@@ -2,13 +2,13 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.model
+package pw.idrug.connections.model
 
 import android.graphics.drawable.Drawable
 import androidx.databinding.BaseObservable
 import androidx.databinding.Bindable
-import org.amnezia.awg.BR
-import org.amnezia.awg.databinding.Keyed
+import pw.idrug.connections.BR
+import pw.idrug.connections.databinding.Keyed
 
 class ApplicationData(val icon: Drawable, val name: String, val packageName: String, isSelected: Boolean) : BaseObservable(), Keyed<String> {
     override val key = name

--- a/ui/src/main/java/org/amnezia/awg/model/ObservableTunnel.kt
+++ b/ui/src/main/java/org/amnezia/awg/model/ObservableTunnel.kt
@@ -2,23 +2,23 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.model
+package pw.idrug.connections.model
 
 import android.util.Log
 import androidx.databinding.BaseObservable
 import androidx.databinding.Bindable
-import org.amnezia.awg.BR
-import org.amnezia.awg.backend.Statistics
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.databinding.Keyed
-import org.amnezia.awg.util.applicationScope
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.BR
+import pw.idrug.connections.backend.Statistics
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.databinding.Keyed
+import pw.idrug.connections.util.applicationScope
+import pw.idrug.connections.config.Config
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Encapsulates the volatile and nonvolatile state of an AmneziaWG tunnel.
+ * Encapsulates the volatile and nonvolatile state of an iDrugConnections tunnel.
  */
 class ObservableTunnel internal constructor(
     private val manager: TunnelManager,
@@ -141,6 +141,6 @@ class ObservableTunnel internal constructor(
 
 
     companion object {
-        private const val TAG = "AmneziaWG/ObservableTunnel"
+        private const val TAG = "iDrugConnections/ObservableTunnel"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/model/TunnelComparator.kt
+++ b/ui/src/main/java/org/amnezia/awg/model/TunnelComparator.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.model
+package pw.idrug.connections.model
 
 object TunnelComparator : Comparator<String> {
     private class NaturalSortString(originalString: String) {

--- a/ui/src/main/java/org/amnezia/awg/model/TunnelManager.kt
+++ b/ui/src/main/java/org/amnezia/awg/model/TunnelManager.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.model
+package pw.idrug.connections.model
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -12,19 +12,19 @@ import android.util.Log
 import android.widget.Toast
 import androidx.databinding.BaseObservable
 import androidx.databinding.Bindable
-import org.amnezia.awg.Application.Companion.get
-import org.amnezia.awg.Application.Companion.getBackend
-import org.amnezia.awg.Application.Companion.getTunnelManager
-import org.amnezia.awg.BR
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.Statistics
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.configStore.ConfigStore
-import org.amnezia.awg.databinding.ObservableSortedKeyedArrayList
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.UserKnobs
-import org.amnezia.awg.util.applicationScope
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.Application.Companion.get
+import pw.idrug.connections.Application.Companion.getBackend
+import pw.idrug.connections.Application.Companion.getTunnelManager
+import pw.idrug.connections.BR
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.Statistics
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.configStore.ConfigStore
+import pw.idrug.connections.databinding.ObservableSortedKeyedArrayList
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.UserKnobs
+import pw.idrug.connections.util.applicationScope
+import pw.idrug.connections.config.Config
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -35,7 +35,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
- * Maintains and mediates changes to the set of available AmneziaWG tunnels,
+ * Maintains and mediates changes to the set of available iDrugConnections tunnels,
  */
 class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
     private val tunnels = CompletableDeferred<ObservableSortedKeyedArrayList<String, ObservableTunnel>>()
@@ -217,7 +217,7 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
                 val manager = getTunnelManager()
                 if (intent == null) return@launch
                 val action = intent.action ?: return@launch
-                if ("org.amnezia.awg.action.REFRESH_TUNNEL_STATES" == action) {
+                if ("pw.idrug.connections.action.REFRESH_TUNNEL_STATES" == action) {
                     manager.refreshTunnelStates()
                     return@launch
                 }
@@ -225,8 +225,8 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
                     return@launch
                 val state: Tunnel.State
                 state = when (action) {
-                    "org.amnezia.awg.action.SET_TUNNEL_UP" -> Tunnel.State.UP
-                    "org.amnezia.awg.action.SET_TUNNEL_DOWN" -> Tunnel.State.DOWN
+                    "pw.idrug.connections.action.SET_TUNNEL_UP" -> Tunnel.State.UP
+                    "pw.idrug.connections.action.SET_TUNNEL_DOWN" -> Tunnel.State.DOWN
                     else -> return@launch
                 }
                 val tunnelName = intent.getStringExtra("tunnel") ?: return@launch
@@ -250,6 +250,6 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/TunnelManager"
+        private const val TAG = "iDrugConnections/TunnelManager"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/preference/KernelModuleEnablerPreference.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/KernelModuleEnablerPreference.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import android.content.Context
 import android.content.Intent
@@ -10,14 +10,14 @@ import android.util.AttributeSet
 import android.util.Log
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.activity.SettingsActivity
-import org.amnezia.awg.backend.Tunnel
-import org.amnezia.awg.backend.AwgQuickBackend
-import org.amnezia.awg.util.UserKnobs
-import org.amnezia.awg.util.activity
-import org.amnezia.awg.util.lifecycleScope
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.activity.SettingsActivity
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.backend.AwgQuickBackend
+import pw.idrug.connections.util.UserKnobs
+import pw.idrug.connections.util.activity
+import pw.idrug.connections.util.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -83,6 +83,6 @@ class KernelModuleEnablerPreference(context: Context, attrs: AttributeSet?) : Pr
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/KernelModuleEnablerPreference"
+        private const val TAG = "iDrugConnections/KernelModuleEnablerPreference"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/preference/PreferencesPreferenceDataStore.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/PreferencesPreferenceDataStore.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences

--- a/ui/src/main/java/org/amnezia/awg/preference/QuickTilePreference.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/QuickTilePreference.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import android.app.StatusBarManager
 import android.content.ComponentName
@@ -14,8 +14,8 @@ import android.util.AttributeSet
 import android.widget.Toast
 import androidx.annotation.RequiresApi
 import androidx.preference.Preference
-import org.amnezia.awg.QuickTileService
-import org.amnezia.awg.R
+import pw.idrug.connections.QuickTileService
+import pw.idrug.connections.R
 
 @RequiresApi(Build.VERSION_CODES.TIRAMISU)
 class QuickTilePreference(context: Context, attrs: AttributeSet?) : Preference(context, attrs) {

--- a/ui/src/main/java/org/amnezia/awg/preference/ToolsInstallerPreference.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/ToolsInstallerPreference.kt
@@ -2,15 +2,15 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import android.content.Context
 import android.util.AttributeSet
 import androidx.preference.Preference
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.util.ToolsInstaller
-import org.amnezia.awg.util.lifecycleScope
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.util.ToolsInstaller
+import pw.idrug.connections.util.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/ui/src/main/java/org/amnezia/awg/preference/VersionPreference.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/VersionPreference.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import android.content.Context
 import android.content.Intent
@@ -10,14 +10,14 @@ import android.net.Uri
 import android.util.AttributeSet
 import android.widget.Toast
 import androidx.preference.Preference
-import org.amnezia.awg.Application
-import org.amnezia.awg.BuildConfig
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.Backend
-import org.amnezia.awg.backend.GoBackend
-import org.amnezia.awg.backend.AwgQuickBackend
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.lifecycleScope
+import pw.idrug.connections.Application
+import pw.idrug.connections.BuildConfig
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.Backend
+import pw.idrug.connections.backend.GoBackend
+import pw.idrug.connections.backend.AwgQuickBackend
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext

--- a/ui/src/main/java/org/amnezia/awg/preference/ZipExporterPreference.kt
+++ b/ui/src/main/java/org/amnezia/awg/preference/ZipExporterPreference.kt
@@ -2,21 +2,21 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.preference
+package pw.idrug.connections.preference
 
 import android.content.Context
 import android.util.AttributeSet
 import android.util.Log
 import androidx.preference.Preference
 import com.google.android.material.snackbar.Snackbar
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.util.AdminKnobs
-import org.amnezia.awg.util.BiometricAuthenticator
-import org.amnezia.awg.util.DownloadsFileSaver
-import org.amnezia.awg.util.ErrorMessages
-import org.amnezia.awg.util.activity
-import org.amnezia.awg.util.lifecycleScope
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.util.AdminKnobs
+import pw.idrug.connections.util.BiometricAuthenticator
+import pw.idrug.connections.util.DownloadsFileSaver
+import pw.idrug.connections.util.ErrorMessages
+import pw.idrug.connections.util.activity
+import pw.idrug.connections.util.lifecycleScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -108,6 +108,6 @@ class ZipExporterPreference(context: Context, attrs: AttributeSet?) : Preference
     }
 
     companion object {
-        private const val TAG = "AmneziaWG/ZipExporterPreference"
+        private const val TAG = "iDrugConnections/ZipExporterPreference"
     }
 }

--- a/ui/src/main/java/org/amnezia/awg/util/AdminKnobs.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/AdminKnobs.kt
@@ -3,11 +3,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.RestrictionsManager
 import androidx.core.content.getSystemService
-import org.amnezia.awg.Application
+import pw.idrug.connections.Application
 
 object AdminKnobs {
     private val restrictions: RestrictionsManager? = Application.get().getSystemService()

--- a/ui/src/main/java/org/amnezia/awg/util/BiometricAuthenticator.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/BiometricAuthenticator.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.os.Handler
 import android.os.Looper
@@ -13,11 +13,11 @@ import androidx.biometric.BiometricManager
 import androidx.biometric.BiometricManager.Authenticators
 import androidx.biometric.BiometricPrompt
 import androidx.fragment.app.Fragment
-import org.amnezia.awg.R
+import pw.idrug.connections.R
 
 
 object BiometricAuthenticator {
-    private const val TAG = "AmneziaWG/BiometricAuthenticator"
+    private const val TAG = "iDrugConnections/BiometricAuthenticator"
 
     // Not all devices support strong biometric auth so we're allowing both device credentials as
     // well as weak biometrics.

--- a/ui/src/main/java/org/amnezia/awg/util/ClipboardUtils.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/ClipboardUtils.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.ClipData
 import android.content.ClipboardManager
@@ -12,7 +12,7 @@ import android.widget.TextView
 import androidx.core.content.getSystemService
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.textfield.TextInputEditText
-import org.amnezia.awg.R
+import pw.idrug.connections.R
 
 /**
  * Standalone utilities for interacting with the system clipboard.

--- a/ui/src/main/java/org/amnezia/awg/util/DownloadsFileSaver.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/DownloadsFileSaver.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.Manifest
 import android.content.ContentValues
@@ -17,7 +17,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
-import org.amnezia.awg.R
+import pw.idrug.connections.R
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext

--- a/ui/src/main/java/org/amnezia/awg/util/ErrorMessages.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/ErrorMessages.kt
@@ -2,22 +2,22 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.res.Resources
 import android.os.RemoteException
 import com.google.zxing.ChecksumException
 import com.google.zxing.NotFoundException
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.backend.BackendException
-import org.amnezia.awg.util.RootShell.RootShellException
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.InetEndpoint
-import org.amnezia.awg.config.InetNetwork
-import org.amnezia.awg.config.ParseException
-import org.amnezia.awg.crypto.Key
-import org.amnezia.awg.crypto.KeyFormatException
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.backend.BackendException
+import pw.idrug.connections.util.RootShell.RootShellException
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.InetEndpoint
+import pw.idrug.connections.config.InetNetwork
+import pw.idrug.connections.config.ParseException
+import pw.idrug.connections.crypto.Key
+import pw.idrug.connections.crypto.KeyFormatException
 import java.net.InetAddress
 
 object ErrorMessages {

--- a/ui/src/main/java/org/amnezia/awg/util/Extensions.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/Extensions.kt
@@ -3,15 +3,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.Context
 import android.util.TypedValue
 import androidx.annotation.AttrRes
 import androidx.lifecycle.lifecycleScope
 import androidx.preference.Preference
-import org.amnezia.awg.Application
-import org.amnezia.awg.activity.SettingsActivity
+import pw.idrug.connections.Application
+import pw.idrug.connections.activity.SettingsActivity
 import kotlinx.coroutines.CoroutineScope
 
 fun Context.resolveAttribute(@AttrRes attrRes: Int): Int {

--- a/ui/src/main/java/org/amnezia/awg/util/QrCodeFromFileScanner.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/QrCodeFromFileScanner.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.ContentResolver
 import android.graphics.Bitmap

--- a/ui/src/main/java/org/amnezia/awg/util/QuantityFormatter.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/QuantityFormatter.kt
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.icu.text.ListFormatter
 import android.icu.text.MeasureFormat
@@ -11,8 +11,8 @@ import android.icu.text.RelativeDateTimeFormatter
 import android.icu.util.Measure
 import android.icu.util.MeasureUnit
 import android.os.Build
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
 import java.util.Locale
 import kotlin.time.Duration.Companion.seconds
 

--- a/ui/src/main/java/org/amnezia/awg/util/TunnelImporter.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/TunnelImporter.kt
@@ -3,18 +3,18 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import android.content.ContentResolver
 import android.net.Uri
 import android.provider.OpenableColumns
 import android.util.Log
 import androidx.fragment.app.FragmentManager
-import org.amnezia.awg.Application
-import org.amnezia.awg.R
-import org.amnezia.awg.fragment.ConfigNamingDialogFragment
-import org.amnezia.awg.model.ObservableTunnel
-import org.amnezia.awg.config.Config
+import pw.idrug.connections.Application
+import pw.idrug.connections.R
+import pw.idrug.connections.fragment.ConfigNamingDialogFragment
+import pw.idrug.connections.model.ObservableTunnel
+import pw.idrug.connections.config.Config
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -148,5 +148,5 @@ object TunnelImporter {
         messageCallback(message)
     }
 
-    private const val TAG = "AmneziaWG/TunnelImporter"
+    private const val TAG = "iDrugConnections/TunnelImporter"
 }

--- a/ui/src/main/java/org/amnezia/awg/util/UserKnobs.kt
+++ b/ui/src/main/java/org/amnezia/awg/util/UserKnobs.kt
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.util
+package pw.idrug.connections.util
 
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
-import org.amnezia.awg.Application
+import pw.idrug.connections.Application
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 

--- a/ui/src/main/java/org/amnezia/awg/viewmodel/ConfigProxy.kt
+++ b/ui/src/main/java/org/amnezia/awg/viewmodel/ConfigProxy.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.viewmodel
+package pw.idrug.connections.viewmodel
 
 import android.os.Build
 import android.os.Parcel
@@ -10,9 +10,9 @@ import android.os.Parcelable
 import androidx.core.os.ParcelCompat
 import androidx.databinding.ObservableArrayList
 import androidx.databinding.ObservableList
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.Config
-import org.amnezia.awg.config.Peer
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.Config
+import pw.idrug.connections.config.Peer
 
 class ConfigProxy : Parcelable {
     val `interface`: InterfaceProxy

--- a/ui/src/main/java/org/amnezia/awg/viewmodel/InterfaceProxy.kt
+++ b/ui/src/main/java/org/amnezia/awg/viewmodel/InterfaceProxy.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.viewmodel
+package pw.idrug.connections.viewmodel
 
 import android.os.Parcel
 import android.os.Parcelable
@@ -10,13 +10,13 @@ import androidx.databinding.BaseObservable
 import androidx.databinding.Bindable
 import androidx.databinding.ObservableArrayList
 import androidx.databinding.ObservableList
-import org.amnezia.awg.BR
-import org.amnezia.awg.config.Attribute
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.Interface
-import org.amnezia.awg.crypto.Key
-import org.amnezia.awg.crypto.KeyFormatException
-import org.amnezia.awg.crypto.KeyPair
+import pw.idrug.connections.BR
+import pw.idrug.connections.config.Attribute
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.Interface
+import pw.idrug.connections.crypto.Key
+import pw.idrug.connections.crypto.KeyFormatException
+import pw.idrug.connections.crypto.KeyPair
 
 class InterfaceProxy : BaseObservable, Parcelable {
     @get:Bindable

--- a/ui/src/main/java/org/amnezia/awg/viewmodel/PeerProxy.kt
+++ b/ui/src/main/java/org/amnezia/awg/viewmodel/PeerProxy.kt
@@ -2,7 +2,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.viewmodel
+package pw.idrug.connections.viewmodel
 
 import android.os.Parcel
 import android.os.Parcelable
@@ -11,10 +11,10 @@ import androidx.databinding.Bindable
 import androidx.databinding.Observable
 import androidx.databinding.Observable.OnPropertyChangedCallback
 import androidx.databinding.ObservableList
-import org.amnezia.awg.BR
-import org.amnezia.awg.config.Attribute
-import org.amnezia.awg.config.BadConfigException
-import org.amnezia.awg.config.Peer
+import pw.idrug.connections.BR
+import pw.idrug.connections.config.Attribute
+import pw.idrug.connections.config.BadConfigException
+import pw.idrug.connections.config.Peer
 import java.lang.ref.WeakReference
 
 class PeerProxy : BaseObservable, Parcelable {

--- a/ui/src/main/java/org/amnezia/awg/widget/KeyInputFilter.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/KeyInputFilter.kt
@@ -2,15 +2,15 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.text.InputFilter
 import android.text.SpannableStringBuilder
 import android.text.Spanned
-import org.amnezia.awg.crypto.Key
+import pw.idrug.connections.crypto.Key
 
 /**
- * InputFilter for entering AmneziaWG private/public keys encoded with base64.
+ * InputFilter for entering iDrugConnections private/public keys encoded with base64.
  */
 class KeyInputFilter : InputFilter {
     override fun filter(

--- a/ui/src/main/java/org/amnezia/awg/widget/MultiselectableRelativeLayout.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/MultiselectableRelativeLayout.kt
@@ -2,13 +2,13 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import android.widget.RelativeLayout
-import org.amnezia.awg.R
+import pw.idrug.connections.R
 
 class MultiselectableRelativeLayout @JvmOverloads constructor(
     context: Context? = null,

--- a/ui/src/main/java/org/amnezia/awg/widget/NameInputFilter.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/NameInputFilter.kt
@@ -2,15 +2,15 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.text.InputFilter
 import android.text.SpannableStringBuilder
 import android.text.Spanned
-import org.amnezia.awg.backend.Tunnel
+import pw.idrug.connections.backend.Tunnel
 
 /**
- * InputFilter for entering AmneziaWG configuration names (Linux interface names).
+ * InputFilter for entering iDrugConnections configuration names (Linux interface names).
  */
 class NameInputFilter : InputFilter {
     override fun filter(

--- a/ui/src/main/java/org/amnezia/awg/widget/SlashDrawable.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/SlashDrawable.kt
@@ -3,7 +3,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.animation.ObjectAnimator
 import android.content.res.ColorStateList

--- a/ui/src/main/java/org/amnezia/awg/widget/ToggleSwitch.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/ToggleSwitch.kt
@@ -3,7 +3,7 @@
  * Copyright © 2017-2023 WireGuard LLC. All Rights Reserved.
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.content.Context
 import android.os.Parcelable

--- a/ui/src/main/java/org/amnezia/awg/widget/TvCardView.kt
+++ b/ui/src/main/java/org/amnezia/awg/widget/TvCardView.kt
@@ -3,13 +3,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-package org.amnezia.awg.widget
+package pw.idrug.connections.widget
 
 import android.content.Context
 import android.util.AttributeSet
 import android.view.View
 import com.google.android.material.card.MaterialCardView
-import org.amnezia.awg.R
+import pw.idrug.connections.R
 
 class TvCardView(context: Context?, attrs: AttributeSet?) : MaterialCardView(context, attrs) {
     var isUp: Boolean = false

--- a/ui/src/main/res/layout-sw600dp/main_activity.xml
+++ b/ui/src/main/res/layout-sw600dp/main_activity.xml
@@ -17,7 +17,7 @@
 
         <androidx.fragment.app.FragmentContainerView
             android:id="@+id/list_fragment"
-            android:name="org.amnezia.awg.fragment.TunnelListFragment"
+            android:name="pw.idrug.connections.fragment.TunnelListFragment"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="2"

--- a/ui/src/main/res/layout/app_list_dialog_fragment.xml
+++ b/ui/src/main/res/layout/app_list_dialog_fragment.xml
@@ -7,15 +7,15 @@
 
         <import type="android.view.View" />
 
-        <import type="org.amnezia.awg.model.ApplicationData" />
+        <import type="pw.idrug.connections.model.ApplicationData" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.AppListDialogFragment" />
+            type="pw.idrug.connections.fragment.AppListDialogFragment" />
 
         <variable
             name="appData"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, ApplicationData&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, ApplicationData&gt;" />
     </data>
 
     <LinearLayout

--- a/ui/src/main/res/layout/app_list_item.xml
+++ b/ui/src/main/res/layout/app_list_item.xml
@@ -4,11 +4,11 @@
 
     <data>
 
-        <import type="org.amnezia.awg.model.ApplicationData" />
+        <import type="pw.idrug.connections.model.ApplicationData" />
 
         <variable
             name="collection"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, org.amnezia.awg.model.ApplicationData&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, pw.idrug.connections.model.ApplicationData&gt;" />
 
         <variable
             name="key"
@@ -16,7 +16,7 @@
 
         <variable
             name="item"
-            type="org.amnezia.awg.model.ApplicationData" />
+            type="pw.idrug.connections.model.ApplicationData" />
     </data>
 
     <LinearLayout

--- a/ui/src/main/res/layout/config_naming_dialog_fragment.xml
+++ b/ui/src/main/res/layout/config_naming_dialog_fragment.xml
@@ -4,7 +4,7 @@
 
     <data>
 
-        <import type="org.amnezia.awg.widget.NameInputFilter" />
+        <import type="pw.idrug.connections.widget.NameInputFilter" />
     </data>
 
     <FrameLayout

--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -5,21 +5,21 @@
 
     <data>
 
-        <import type="org.amnezia.awg.backend.Tunnel.State" />
+        <import type="pw.idrug.connections.backend.Tunnel.State" />
 
-        <import type="org.amnezia.awg.util.ClipboardUtils" />
+        <import type="pw.idrug.connections.util.ClipboardUtils" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.TunnelDetailFragment" />
+            type="pw.idrug.connections.fragment.TunnelDetailFragment" />
 
         <variable
             name="tunnel"
-            type="org.amnezia.awg.model.ObservableTunnel" />
+            type="pw.idrug.connections.model.ObservableTunnel" />
 
         <variable
             name="config"
-            type="org.amnezia.awg.config.Config" />
+            type="pw.idrug.connections.config.Config" />
     </data>
 
     <ScrollView
@@ -57,7 +57,7 @@
                         app:layout_constraintStart_toStartOf="parent"
                         app:layout_constraintTop_toTopOf="parent" />
 
-                    <org.amnezia.awg.widget.ToggleSwitch
+                    <pw.idrug.connections.widget.ToggleSwitch
                         android:id="@+id/tunnel_switch"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"

--- a/ui/src/main/res/layout/tunnel_detail_peer.xml
+++ b/ui/src/main/res/layout/tunnel_detail_peer.xml
@@ -5,11 +5,11 @@
 
     <data>
 
-        <import type="org.amnezia.awg.util.ClipboardUtils" />
+        <import type="pw.idrug.connections.util.ClipboardUtils" />
 
         <variable
             name="item"
-            type="org.amnezia.awg.config.Peer" />
+            type="pw.idrug.connections.config.Peer" />
     </data>
 
     <com.google.android.material.card.MaterialCardView

--- a/ui/src/main/res/layout/tunnel_editor_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_editor_fragment.xml
@@ -5,19 +5,19 @@
 
     <data>
 
-        <import type="org.amnezia.awg.util.ClipboardUtils" />
+        <import type="pw.idrug.connections.util.ClipboardUtils" />
 
-        <import type="org.amnezia.awg.widget.KeyInputFilter" />
+        <import type="pw.idrug.connections.widget.KeyInputFilter" />
 
-        <import type="org.amnezia.awg.widget.NameInputFilter" />
+        <import type="pw.idrug.connections.widget.NameInputFilter" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.TunnelEditorFragment" />
+            type="pw.idrug.connections.fragment.TunnelEditorFragment" />
 
         <variable
             name="config"
-            type="org.amnezia.awg.viewmodel.ConfigProxy" />
+            type="pw.idrug.connections.viewmodel.ConfigProxy" />
 
         <variable
             name="name"

--- a/ui/src/main/res/layout/tunnel_editor_peer.xml
+++ b/ui/src/main/res/layout/tunnel_editor_peer.xml
@@ -6,21 +6,21 @@
 
         <import type="android.view.View" />
 
-        <import type="org.amnezia.awg.widget.KeyInputFilter" />
+        <import type="pw.idrug.connections.widget.KeyInputFilter" />
 
-        <import type="org.amnezia.awg.databinding.BindingAdapters" />
+        <import type="pw.idrug.connections.databinding.BindingAdapters" />
 
         <variable
             name="collection"
-            type="androidx.databinding.ObservableList&lt;org.amnezia.awg.viewmodel.PeerProxy&gt;" />
+            type="androidx.databinding.ObservableList&lt;pw.idrug.connections.viewmodel.PeerProxy&gt;" />
 
         <variable
             name="item"
-            type="org.amnezia.awg.viewmodel.PeerProxy" />
+            type="pw.idrug.connections.viewmodel.PeerProxy" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.TunnelEditorFragment" />
+            type="pw.idrug.connections.fragment.TunnelEditorFragment" />
     </data>
 
     <com.google.android.material.card.MaterialCardView

--- a/ui/src/main/res/layout/tunnel_list_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_list_fragment.xml
@@ -5,19 +5,19 @@
 
     <data>
 
-        <import type="org.amnezia.awg.model.ObservableTunnel" />
+        <import type="pw.idrug.connections.model.ObservableTunnel" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.TunnelListFragment" />
+            type="pw.idrug.connections.fragment.TunnelListFragment" />
 
         <variable
             name="rowConfigurationHandler"
-            type="org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
+            type="pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
 
         <variable
             name="tunnels"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
     </data>
 
     <androidx.coordinatorlayout.widget.CoordinatorLayout

--- a/ui/src/main/res/layout/tunnel_list_item.xml
+++ b/ui/src/main/res/layout/tunnel_list_item.xml
@@ -5,13 +5,13 @@
 
     <data>
 
-        <import type="org.amnezia.awg.model.ObservableTunnel" />
+        <import type="pw.idrug.connections.model.ObservableTunnel" />
 
-        <import type="org.amnezia.awg.backend.Tunnel.State" />
+        <import type="pw.idrug.connections.backend.Tunnel.State" />
 
         <variable
             name="collection"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
 
         <variable
             name="key"
@@ -19,14 +19,14 @@
 
         <variable
             name="item"
-            type="org.amnezia.awg.model.ObservableTunnel" />
+            type="pw.idrug.connections.model.ObservableTunnel" />
 
         <variable
             name="fragment"
-            type="org.amnezia.awg.fragment.TunnelListFragment" />
+            type="pw.idrug.connections.fragment.TunnelListFragment" />
     </data>
 
-    <org.amnezia.awg.widget.MultiselectableRelativeLayout
+    <pw.idrug.connections.widget.MultiselectableRelativeLayout
         android:id="@+id/tunnel_list_item"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -49,7 +49,7 @@
             android:textAppearance="?attr/textAppearanceBodyLarge"
             tools:text="@sample/interface_names.json/names/names/name" />
 
-        <org.amnezia.awg.widget.ToggleSwitch
+        <pw.idrug.connections.widget.ToggleSwitch
             android:id="@+id/tunnel_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
@@ -59,5 +59,5 @@
             app:checked="@{item.state == State.UP}"
             app:onBeforeCheckedChanged="@{fragment::setTunnelState}"
             tools:checked="@sample/interface_names.json/names/checked/checked" />
-    </org.amnezia.awg.widget.MultiselectableRelativeLayout>
+    </pw.idrug.connections.widget.MultiselectableRelativeLayout>
 </layout>

--- a/ui/src/main/res/layout/tv_activity.xml
+++ b/ui/src/main/res/layout/tv_activity.xml
@@ -7,9 +7,9 @@
 
         <import type="android.view.View" />
 
-        <import type="org.amnezia.awg.model.ObservableTunnel" />
+        <import type="pw.idrug.connections.model.ObservableTunnel" />
 
-        <import type="org.amnezia.awg.activity.TvMainActivity.KeyedFile" />
+        <import type="pw.idrug.connections.activity.TvMainActivity.KeyedFile" />
 
         <variable
             name="isDeleting"
@@ -17,7 +17,7 @@
 
         <variable
             name="files"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, KeyedFile&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, KeyedFile&gt;" />
 
         <variable
             name="filesRoot"
@@ -25,15 +25,15 @@
 
         <variable
             name="tunnels"
-            type="org.amnezia.awg.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
+            type="pw.idrug.connections.databinding.ObservableKeyedArrayList&lt;String, ObservableTunnel&gt;" />
 
         <variable
             name="tunnelRowConfigurationHandler"
-            type="org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
+            type="pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
 
         <variable
             name="filesRowConfigurationHandler"
-            type="org.amnezia.awg.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
+            type="pw.idrug.connections.databinding.ObservableKeyedRecyclerViewAdapter.RowConfigurationHandler" />
     </data>
 
     <androidx.constraintlayout.widget.ConstraintLayout

--- a/ui/src/main/res/layout/tv_file_list_item.xml
+++ b/ui/src/main/res/layout/tv_file_list_item.xml
@@ -4,7 +4,7 @@
 
     <data>
 
-        <import type="org.amnezia.awg.activity.TvMainActivity.KeyedFile" />
+        <import type="pw.idrug.connections.activity.TvMainActivity.KeyedFile" />
 
         <variable
             name="key"

--- a/ui/src/main/res/layout/tv_tunnel_list_item.xml
+++ b/ui/src/main/res/layout/tv_tunnel_list_item.xml
@@ -7,9 +7,9 @@
 
         <import type="android.view.View" />
 
-        <import type="org.amnezia.awg.model.ObservableTunnel" />
+        <import type="pw.idrug.connections.model.ObservableTunnel" />
 
-        <import type="org.amnezia.awg.backend.Tunnel.State" />
+        <import type="pw.idrug.connections.backend.Tunnel.State" />
 
         <variable
             name="isDeleting"
@@ -25,10 +25,10 @@
 
         <variable
             name="item"
-            type="org.amnezia.awg.model.ObservableTunnel" />
+            type="pw.idrug.connections.model.ObservableTunnel" />
     </data>
 
-    <org.amnezia.awg.widget.TvCardView
+    <pw.idrug.connections.widget.TvCardView
         android:layout_width="225dp"
         android:layout_height="110dp"
         android:layout_margin="8dp"
@@ -77,6 +77,6 @@
 
         </androidx.constraintlayout.widget.ConstraintLayout>
 
-    </org.amnezia.awg.widget.TvCardView>
+    </pw.idrug.connections.widget.TvCardView>
 
 </layout>

--- a/ui/src/main/res/values-ar-rSA/strings.xml
+++ b/ui/src/main/res/values-ar-rSA/strings.xml
@@ -225,7 +225,7 @@
     <string name="parse_error_integer">رقم</string>
     <string name="parse_error_reason">لا يمكن تحليل %1$s \"%2$s\"</string>
     <string name="peer">ند</string>
-    <string name="permission_description">التحكم في أنفاق AmneziaWG، وتمكين الأنفاق وتعطيلها حسب الرغبة، مما قد يؤدي إلى تضليل حركة مرور الإنترنت</string>
+    <string name="permission_description">التحكم في أنفاق iDrugConnections، وتمكين الأنفاق وتعطيلها حسب الرغبة، مما قد يؤدي إلى تضليل حركة مرور الإنترنت</string>
     <string name="permission_label">التحكم في أنفاق وايرجارد</string>
     <string name="persistent_keepalive">الحفاظ المستمر</string>
     <string name="pre_shared_key">مفتاح مسبق التشارك (Pre-shared key)</string>

--- a/ui/src/main/res/values-ca-rES/strings.xml
+++ b/ui/src/main/res/values-ca-rES/strings.xml
@@ -87,7 +87,7 @@
     <string name="config_rename_error">No es pot cambiar el nom del fitxer de configuració \"%s\"</string>
     <string name="config_save_error">No es pot guardar la configuraxió per \"%1$s\": %2$s</string>
     <string name="config_save_success">La configuració per \"%s\" s\'ha guadat correctament</string>
-    <string name="create_activity_title">Crear túnel AmneziaWG</string>
+    <string name="create_activity_title">Crear túnel iDrugConnections</string>
     <string name="create_bin_dir_error">No s\'ha pogut crear la carpeta local pels binaris</string>
     <string name="create_downloads_file_error">No es pot crear arxiu en la carpeta de descàrregues</string>
     <string name="create_empty">Crea des de zero</string>
@@ -129,12 +129,12 @@
     <string name="interface_title">Interfície</string>
     <string name="key_contents_error">Caràcters incorrectes en la clau</string>
     <string name="key_length_error">Longitud de clau incorrecta</string>
-    <string name="key_length_explanation_base64">: Les claus en base64 a AmneziaWG han de tenir 44 caràcters (32 bytes)</string>
-    <string name="key_length_explanation_binary">: Les claus AmneziaWG han de ser de 32 bytes</string>
-    <string name="key_length_explanation_hex">: Les claus en hexadecimal a AmneziaWG han de tenir 64 caràcters (32 bytes)</string>
+    <string name="key_length_explanation_base64">: Les claus en base64 a iDrugConnections han de tenir 44 caràcters (32 bytes)</string>
+    <string name="key_length_explanation_binary">: Les claus iDrugConnections han de ser de 32 bytes</string>
+    <string name="key_length_explanation_hex">: Les claus en hexadecimal a iDrugConnections han de tenir 64 caràcters (32 bytes)</string>
     <string name="listen_port">Port d\'escolta</string>
     <string name="log_export_error">No s\'ha estat capaç d\'exportar el registre: %s</string>
-    <string name="log_export_subject">AmneziaWG Android Log File</string>
+    <string name="log_export_subject">iDrugConnections Android Log File</string>
     <string name="log_export_success">Guardat a \"%s\"</string>
     <string name="log_export_title">Exporta el registre</string>
     <string name="log_saver_activity_label">Guarda registre</string>
@@ -164,8 +164,8 @@
     <string name="parse_error_integer">número</string>
     <string name="parse_error_reason">No es pot analitzar %1$s \"%2$s\"</string>
     <string name="peer">Parell</string>
-    <string name="permission_description">controla els túnels de AmneziaWG, habilitant i deshabilitant túnels a discreció, potencialment desviant el trànsit</string>
-    <string name="permission_label">controla els túnels AmneziaWG</string>
+    <string name="permission_description">controla els túnels de iDrugConnections, habilitant i deshabilitant túnels a discreció, potencialment desviant el trànsit</string>
+    <string name="permission_label">controla els túnels iDrugConnections</string>
     <string name="persistent_keepalive">Missatge de persistència</string>
     <string name="pre_shared_key">Clau precompartida</string>
     <string name="pre_shared_key_enabled">activat</string>
@@ -183,7 +183,7 @@
     <string name="shell_start_error">No s\'ha pogut iniciar: %d</string>
     <string name="success_application_will_restart">Èxit. Ara l\'aplicació es reiniciarà…</string>
     <string name="toggle_all">Canviar tot</string>
-    <string name="toggle_error">Error al canviar el túnel AmneziaWG: %s</string>
+    <string name="toggle_error">Error al canviar el túnel iDrugConnections: %s</string>
     <string name="tools_installer_already">awg i awg-quick ja estan instalats</string>
     <string name="tools_installer_failure">No s\'ha pogut instalar les eines de linia de comandes (ets root?)</string>
     <string name="tools_installer_success_magisk">awg i awg-quick instalats com a mòdul de Magisk (es necessita reinicar)</string>
@@ -212,7 +212,7 @@
     <string name="type_name_kernel_module">Mòdul del kernel</string>
     <string name="unknown_error">Error desconegut</string>
     <string name="version_summary_unknown">Versió de %s desconeguda</string>
-    <string name="version_title">AmneziaWG per a Android v%s</string>
+    <string name="version_title">iDrugConnections per a Android v%s</string>
     <string name="vpn_not_authorized_error">Servei de VPN no autoritzat per l\'usuari</string>
     <string name="vpn_start_error">No s\'ha pogut iniciar el servei de VPN de Android</string>
     <string name="zip_export_error">No s\'han pogut exportar els túnels: %s</string>

--- a/ui/src/main/res/values-cs-rCZ/strings.xml
+++ b/ui/src/main/res/values-cs-rCZ/strings.xml
@@ -113,7 +113,7 @@
     <string name="config_rename_error">Konfigurační soubor „%s“ nelze přejmenovat</string>
     <string name="config_save_error">Nelze uložit konfiguraci pro „%1$s“: %2$s</string>
     <string name="config_save_success">Konfigurace pro „%s“ byla úspěšně uložena</string>
-    <string name="create_activity_title">Vytvořit AmneziaWG tunel</string>
+    <string name="create_activity_title">Vytvořit iDrugConnections tunel</string>
     <string name="delete">Smazat</string>
     <string name="log_viewer_pref_summary">Logy mohou pomoci s debuggingem</string>
     <string name="log_viewer_pref_title">Zobrazit log aplikace</string>

--- a/ui/src/main/res/values-da-rDK/strings.xml
+++ b/ui/src/main/res/values-da-rDK/strings.xml
@@ -85,7 +85,7 @@
     <string name="config_rename_error">Kan ikke omdøbe konfigurationsfilen \"%s\"</string>
     <string name="config_save_error">Kan ikke gemme konfigurationen for \"%1$s\": %2$s</string>
     <string name="config_save_success">Konfiguration for \"%s\" blev gemt</string>
-    <string name="create_activity_title">Opret AmneziaWG tunnel</string>
+    <string name="create_activity_title">Opret iDrugConnections tunnel</string>
     <string name="create_empty">Opret fra ny</string>
     <string name="create_from_file">Importér fra fil eller arkiv</string>
     <string name="create_from_qr_code">Scan fra QR-kode</string>
@@ -123,7 +123,7 @@
     <string name="latest_handshake_ago">%s siden</string>
     <string name="listen_port">Lytteport</string>
     <string name="log_export_error">Kunne ikke eksportere log: %s</string>
-    <string name="log_export_subject">AmneziaWG Android Log-fil</string>
+    <string name="log_export_subject">iDrugConnections Android Log-fil</string>
     <string name="log_export_success">Gemt til \"%s\"</string>
     <string name="log_export_title">Eksportér log-fil</string>
     <string name="log_saver_activity_label">Gem log</string>
@@ -177,7 +177,7 @@
     <string name="type_name_kernel_module">Kerne modul</string>
     <string name="unknown_error">Ukendt fejl</string>
     <string name="version_summary_unknown">Ukendt %s version</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="zip_export_error">Ikke i stand til at eksportere tunneler: %s</string>
     <string name="zip_export_success">Gemt til \"%s\"</string>
     <string name="zip_export_title">Eksportér tunneler til zip-fil</string>

--- a/ui/src/main/res/values-de/strings.xml
+++ b/ui/src/main/res/values-de/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Konfigurationsdatei „%s “ kann nicht umbenannt werden</string>
     <string name="config_save_error">Konfiguration für „%1$s“ kann nicht gespeichert werden: %2$s</string>
     <string name="config_save_success">Konfiguration für „%s ” erfolgreich gespeichert</string>
-    <string name="create_activity_title">AmneziaWG-Tunnel erstellen</string>
+    <string name="create_activity_title">iDrugConnections-Tunnel erstellen</string>
     <string name="create_bin_dir_error">Lokales Anwendungsverzeichnis kann nicht erstellt werden</string>
     <string name="create_downloads_file_error">Datei kann im Download-Verzeichnis nicht erstellt werden</string>
     <string name="create_empty">Neu erstellen</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Unzulässige Zeichen im Schlüssel</string>
     <string name="key_length_error">Falsche Schlüssellänge</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64-Schlüssel müssen 44 Zeichen enthalten (32 Bytes)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG-Schlüssel müssen 32 Bytes groß sein</string>
-    <string name="key_length_explanation_hex">: AmneziaWG Hex-Schlüssel müssen 64 Zeichen (32 Bytes) groß sein</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64-Schlüssel müssen 44 Zeichen enthalten (32 Bytes)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections-Schlüssel müssen 32 Bytes groß sein</string>
+    <string name="key_length_explanation_hex">: iDrugConnections Hex-Schlüssel müssen 64 Zeichen (32 Bytes) groß sein</string>
     <string name="latest_handshake">Letzter Handshake</string>
     <string name="latest_handshake_ago">vor %s</string>
     <string name="listen_port">Eingangs-Port</string>
     <string name="log_export_error">Konnte Protokoll nicht exportieren: %s</string>
-    <string name="log_export_subject">AmneziaWG Android Protokolldatei</string>
+    <string name="log_export_subject">iDrugConnections Android Protokolldatei</string>
     <string name="log_export_success">Gespeichert in „%s”</string>
     <string name="log_export_title">Logdatei exportieren</string>
     <string name="log_saver_activity_label">Protokoll speichern</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">Zahl</string>
     <string name="parse_error_reason">Kann %1$s “%2$s ” nicht verarbeiten</string>
     <string name="peer">Teilnehmer</string>
-    <string name="permission_description">AmneziaWG-Tunnel steuern, Tunnel aktivieren und nach Belieben deaktivieren, wodurch der Internetverkehr möglicherweise falsch geleitet wird</string>
-    <string name="permission_label">AmneziaWG-Tunnel steuern</string>
+    <string name="permission_description">iDrugConnections-Tunnel steuern, Tunnel aktivieren und nach Belieben deaktivieren, wodurch der Internetverkehr möglicherweise falsch geleitet wird</string>
+    <string name="permission_label">iDrugConnections-Tunnel steuern</string>
     <string name="persistent_keepalive">Dauerhafte Erhaltung</string>
     <string name="pre_shared_key">Vorab geteilter Schlüssel</string>
     <string name="pre_shared_key_enabled">aktiviert</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">Shell konnte nicht gestartet werden: %d</string>
     <string name="success_application_will_restart">Erfolgreich. Die Anwendung wird nun neu starten…</string>
     <string name="toggle_all">Alle umschalten</string>
-    <string name="toggle_error">Fehler beim Umschalten des AmneziaWG-Tunnels: %s</string>
+    <string name="toggle_error">Fehler beim Umschalten des iDrugConnections-Tunnels: %s</string>
     <string name="tools_installer_already">awg und awg-quick sind bereits installiert</string>
     <string name="tools_installer_failure">Kommandozeilenwerkzeuge konnten nicht installiert werden (kein Root?)</string>
     <string name="tools_installer_initial">Optionale Werkzeuge für Skripte installieren</string>
@@ -232,7 +232,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Überprüfe %s Backend-Version</string>
     <string name="version_summary_unknown">Unbekannte %s Version</string>
-    <string name="version_title">AmneziaWG für Android v%s</string>
+    <string name="version_title">iDrugConnections für Android v%s</string>
     <string name="vpn_not_authorized_error">VPN-Dienst nicht vom Benutzer autorisiert</string>
     <string name="vpn_start_error">Android VPN-Dienst konnte nicht gestartet werden</string>
     <string name="zip_export_error">Kann Tunnel nicht exportieren: %s</string>

--- a/ui/src/main/res/values-el-rGR/strings.xml
+++ b/ui/src/main/res/values-el-rGR/strings.xml
@@ -94,7 +94,7 @@
     <string name="hint_optional">(προαιρετικό)</string>
     <string name="key_contents_error">Μη έγκυροι χαρακτήρες στο κλειδί</string>
     <string name="key_length_error">Εσφαλμένο μήκος κλειδιού</string>
-    <string name="key_length_explanation_binary">: Τα κλειδιά του AmneziaWG πρέπει να είναι 32 bytes</string>
+    <string name="key_length_explanation_binary">: Τα κλειδιά του iDrugConnections πρέπει να είναι 32 bytes</string>
     <string name="log_export_title">Εξαγωγή αρχείου καταγραφής</string>
     <string name="log_saver_activity_label">Αποθήκευση αρχείου καταγραφής</string>
     <string name="log_viewer_title">Αρχείο καταγραφής</string>
@@ -120,7 +120,7 @@
     <string name="tunnel_error_invalid_name">Μη έγκυρο όνομα</string>
     <string name="unknown_error">Άγνωστο σφάλμα</string>
     <string name="version_summary_unknown">Άγνωστη έκδοση %s</string>
-    <string name="version_title">AmneziaWG για Android v%s</string>
+    <string name="version_title">iDrugConnections για Android v%s</string>
     <string name="biometric_auth_error">Αποτυχία ελέγχου ταυτότητας</string>
     <string name="biometric_auth_error_reason">Αποτυχία ελέγχου ταυτότητας: %s</string>
 </resources>

--- a/ui/src/main/res/values-es-rES/strings.xml
+++ b/ui/src/main/res/values-es-rES/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">No se puede renombrar el archivo de configuración “%s”</string>
     <string name="config_save_error">No se puede guardar la configuración para “%1$s”: %2$s</string>
     <string name="config_save_success">Configuración guardada correctamente para “%s”</string>
-    <string name="create_activity_title">Crear túnel AmneziaWG</string>
+    <string name="create_activity_title">Crear túnel iDrugConnections</string>
     <string name="create_bin_dir_error">No se puede crear el directorio binario local</string>
     <string name="create_downloads_file_error">No se puede crear archivo en el directorio de descargas</string>
     <string name="create_empty">Crear de cero</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Interfaz</string>
     <string name="key_contents_error">Caracteres incorrectos en la clave</string>
     <string name="key_length_error">Longitud de clave incorrecta</string>
-    <string name="key_length_explanation_base64">Las claves base64 de AmneziaWG deben tener 44 caracteres (32 bytes)</string>
-    <string name="key_length_explanation_binary">: Las claves AmneziaWG deben tener 32 bytes</string>
+    <string name="key_length_explanation_base64">Las claves base64 de iDrugConnections deben tener 44 caracteres (32 bytes)</string>
+    <string name="key_length_explanation_binary">: Las claves iDrugConnections deben tener 32 bytes</string>
     <string name="key_length_explanation_hex">: Las claves hexadecimales de Wirex deben tener 64 caracteres (32 bytes)</string>
     <string name="latest_handshake">Última comunicación</string>
     <string name="latest_handshake_ago">hace %s</string>
     <string name="listen_port">Puerto de escucha</string>
     <string name="log_export_error">No se pudo exportar el registro: %s</string>
-    <string name="log_export_subject">Archivo de registro AmneziaWG Android</string>
+    <string name="log_export_subject">Archivo de registro iDrugConnections Android</string>
     <string name="log_export_success">Guardado en “%s”</string>
     <string name="log_export_title">Exportar archivo de registro</string>
     <string name="log_saver_activity_label">Guardar registro</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">número</string>
     <string name="parse_error_reason">No se puede analizar %1$s “%2$s”</string>
     <string name="peer">Pares</string>
-    <string name="permission_description">controlar túneles de AmneziaWG, habilitando y desactivando túneles a su antojo, lo que podría conducir mal al tráfico de Internet</string>
-    <string name="permission_label">controlar túneles de AmneziaWG</string>
+    <string name="permission_description">controlar túneles de iDrugConnections, habilitando y desactivando túneles a su antojo, lo que podría conducir mal al tráfico de Internet</string>
+    <string name="permission_label">controlar túneles de iDrugConnections</string>
     <string name="persistent_keepalive">Keepalive persistente</string>
     <string name="pre_shared_key">Clave precompartida</string>
     <string name="pre_shared_key_enabled">activado</string>
@@ -192,7 +192,7 @@
     <string name="shell_start_error">No se pudo iniciar Shell: %d</string>
     <string name="success_application_will_restart">Éxito. La aplicación se reiniciará ahora…</string>
     <string name="toggle_all">Cambiar Todos</string>
-    <string name="toggle_error">Error al cambiar el túnel AmneziaWG: %s</string>
+    <string name="toggle_error">Error al cambiar el túnel iDrugConnections: %s</string>
     <string name="tools_installer_already">awg y awg-quick ya están instalados</string>
     <string name="tools_installer_failure">No se puede instalar herramientas de línea de comandos (sin root?)</string>
     <string name="tools_installer_initial">Instalar herramientas opcionales para el scripting</string>
@@ -228,7 +228,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Comprobando versión de backend %s</string>
     <string name="version_summary_unknown">Versión %s desconocida</string>
-    <string name="version_title">AmneziaWG para Android -%s</string>
+    <string name="version_title">iDrugConnections para Android -%s</string>
     <string name="vpn_not_authorized_error">Servicio VPN no autorizado por el usuario</string>
     <string name="vpn_start_error">No se puede iniciar el servicio VPN Android</string>
     <string name="zip_export_error">No se pueden exportar túneles: %s</string>

--- a/ui/src/main/res/values-et-rEE/strings.xml
+++ b/ui/src/main/res/values-et-rEE/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Seadistusfaili \"%s\" ümbernimetamine ebaõnnestus</string>
     <string name="config_save_error">\"%1$s\" seadistuse salvestamine ebaõnnestus: %2$s</string>
     <string name="config_save_success">\"%s\" seadistus salvestatud</string>
-    <string name="create_activity_title">Loo AmneziaWG tunnel</string>
+    <string name="create_activity_title">Loo iDrugConnections tunnel</string>
     <string name="create_bin_dir_error">Lokaalse programmfaili kataloogi tekitamine ebaõnnestus</string>
     <string name="create_downloads_file_error">Faili loomine allalaadimiste kataloogis ebaõnnestus</string>
     <string name="create_empty">Sisesta käsitsi</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Liides</string>
     <string name="key_contents_error">Lubamatud sümbolid võtmes</string>
     <string name="key_length_error">Sobimatu võtme pikkus</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 võti peab olema 44 sümbolit (32 baiti) pikk</string>
-    <string name="key_length_explanation_binary">: AmneziaWG võtmed peavad olema 32 baiti</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex võti peab olema 64 sümbolit (32 baiti) pikk</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 võti peab olema 44 sümbolit (32 baiti) pikk</string>
+    <string name="key_length_explanation_binary">: iDrugConnections võtmed peavad olema 32 baiti</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex võti peab olema 64 sümbolit (32 baiti) pikk</string>
     <string name="latest_handshake">Viimane kätlus</string>
     <string name="latest_handshake_ago">%s tagasi</string>
     <string name="listen_port">Kuulamisport</string>
     <string name="log_export_error">Logifaili eksportimine ebaõnnestus: %s</string>
-    <string name="log_export_subject">AmneziaWG Android logifail</string>
+    <string name="log_export_subject">iDrugConnections Android logifail</string>
     <string name="log_export_success">Salvestatud faili \"%s\"</string>
     <string name="log_export_title">Ekspordi logifail</string>
     <string name="log_saver_activity_label">Salvesta logi</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">number</string>
     <string name="parse_error_reason">Ei saa töödelda %1$s “%2$s”</string>
     <string name="peer">Partner</string>
-    <string name="permission_description">kontrollida AmneziaWG tunneleid, neid sisse ja välja lülitades, potentsiaalselt võrguliiklust kõrvale juhtides</string>
-    <string name="permission_label">kontrollida AmneziaWG tunneleid</string>
+    <string name="permission_description">kontrollida iDrugConnections tunneleid, neid sisse ja välja lülitades, potentsiaalselt võrguliiklust kõrvale juhtides</string>
+    <string name="permission_label">kontrollida iDrugConnections tunneleid</string>
     <string name="persistent_keepalive">Püsiv ühendushoidik</string>
     <string name="pre_shared_key">Eeljagatud võti</string>
     <string name="pre_shared_key_enabled">lubatud</string>
@@ -193,7 +193,7 @@
     <string name="shell_start_error">Kesta käivitumine ebaõnnestus: %d</string>
     <string name="success_application_will_restart">Tegevus õnnestus. Rakendus taaskäivitub…</string>
     <string name="toggle_all">Vaheta kõik</string>
-    <string name="toggle_error">AmneziaWG tunneli lülitamine ebaõnnestus: %s</string>
+    <string name="toggle_error">iDrugConnections tunneli lülitamine ebaõnnestus: %s</string>
     <string name="tools_installer_already">awg ja awg-quick on juba paigaldatud</string>
     <string name="tools_installer_failure">Käsurea tööriistade paigaldamine ebaõnnestus (juurkasutaja õigused puuduvad?)</string>
     <string name="tools_installer_initial">Paigalda täiendavad tööriistad skriptimiseks</string>
@@ -229,7 +229,7 @@
     <string name="version_summary">%1$s taustsüsteem %2$s</string>
     <string name="version_summary_checking">Kontrollin %s taustsüsteemi versiooni</string>
     <string name="version_summary_unknown">Tundmatu %s versioon</string>
-    <string name="version_title">AmneziaWG Androidile v%s</string>
+    <string name="version_title">iDrugConnections Androidile v%s</string>
     <string name="vpn_not_authorized_error">Kasutaja ei lubanud VPN teenust</string>
     <string name="vpn_start_error">Androidi VPN teenuse käivitamine ebaõnnestus</string>
     <string name="zip_export_error">Tunnelite eksportimine ebaõnnestus: %s</string>

--- a/ui/src/main/res/values-fa-rIR/strings.xml
+++ b/ui/src/main/res/values-fa-rIR/strings.xml
@@ -90,7 +90,7 @@
     <string name="config_rename_error">نمی‌توان نام پرونده پیکربندی “%s” را تغییر داد</string>
     <string name="config_save_error">نمی‌توان پیکربندی برای “%1$s”: %2$s را ذخیره کرد</string>
     <string name="config_save_success">پیکربندی برای “%s” با موفقیت ذخیره شد</string>
-    <string name="create_activity_title">ساخت تونل AmneziaWG</string>
+    <string name="create_activity_title">ساخت تونل iDrugConnections</string>
     <string name="create_bin_dir_error">نمی‌توان دایرکتوری باینری محلی را ایجاد کرد</string>
     <string name="create_downloads_file_error">نمی‌توان در مسیر بارگیری پرونده‌ای ساخت</string>
     <string name="create_empty">ساختن از ابتدا</string>
@@ -133,12 +133,12 @@
     <string name="interface_title">رابط</string>
     <string name="key_contents_error">در کلید نویسه‌های بد وجود دارد</string>
     <string name="key_length_error">طول کلید نادرست است</string>
-    <string name="key_length_explanation_base64">: کلیدهای AmneziaWG base64 باید دارای ۴۴ نویسه باشند ( ۳۲ بایت)</string>
-    <string name="key_length_explanation_binary">: کلیدهای AmneziaWG باید ۳۲ بایت باشند</string>
-    <string name="key_length_explanation_hex">: کلیدهای هگز AmneziaWG باید دارای ۶۴ نویسه باشند ( ۳۲ بایت)</string>
+    <string name="key_length_explanation_base64">: کلیدهای iDrugConnections base64 باید دارای ۴۴ نویسه باشند ( ۳۲ بایت)</string>
+    <string name="key_length_explanation_binary">: کلیدهای iDrugConnections باید ۳۲ بایت باشند</string>
+    <string name="key_length_explanation_hex">: کلیدهای هگز iDrugConnections باید دارای ۶۴ نویسه باشند ( ۳۲ بایت)</string>
     <string name="listen_port">شنود پورت</string>
     <string name="log_export_error">نمی‌توان گزارش رویداد را برون‌برد: %s</string>
-    <string name="log_export_subject">پرونده گزارش رویداد AmneziaWG اندروید</string>
+    <string name="log_export_subject">پرونده گزارش رویداد iDrugConnections اندروید</string>
     <string name="log_export_success">ذخیره شد در “%s”</string>
     <string name="log_export_title">برون‌برد پرونده گزارش رویداد</string>
     <string name="log_saver_activity_label">ذخیره گزارش رویداد</string>
@@ -172,7 +172,7 @@
     <string name="parse_error_reason">نمی‌توان %1$s “%2$s” تجزیه کرد</string>
     <string name="peer">همتا</string>
     <string name="permission_description">کنترل تونل های وایرگارد، فعال و غیرفعال کردن تونل ها، و حتی تغییر مسیر ترافیک اینترنت</string>
-    <string name="permission_label">کنترل تونل‌های AmneziaWG</string>
+    <string name="permission_label">کنترل تونل‌های iDrugConnections</string>
     <string name="persistent_keepalive">زنده نگه‌داشتن پیوسته</string>
     <string name="pre_shared_key">کلید از پیش تقسیم شده</string>
     <string name="pre_shared_key_enabled">فعال شده</string>
@@ -190,7 +190,7 @@
     <string name="shell_start_error">آغاز پوسته شکست خورد: %d</string>
     <string name="success_application_will_restart">موفقیت. برنامه اکنون دوباره راه‌اندازی خواهد شد…</string>
     <string name="toggle_all">معکوس کردن همه</string>
-    <string name="toggle_error">خطا در ضامن تونل AmneziaWG: %s</string>
+    <string name="toggle_error">خطا در ضامن تونل iDrugConnections: %s</string>
     <string name="tools_installer_already">awg و awg-quick قبلاً نصب شده اند</string>
     <string name="tools_installer_failure">ابزارهای خط-فرمان نصب نمی‌شود (روت نیستید؟)</string>
     <string name="tools_installer_initial">ابزارهای اختیاری را برای اسکریپت نویسی نصب کنید</string>
@@ -226,7 +226,7 @@
     <string name="version_summary">%1$s بک اند %2$s</string>
     <string name="version_summary_checking">در حال بررسی نگارش پس‌زمینه %s</string>
     <string name="version_summary_unknown">نگارش %s ناشناخته</string>
-    <string name="version_title">AmneziaWG برای اندروید نگارش %s</string>
+    <string name="version_title">iDrugConnections برای اندروید نگارش %s</string>
     <string name="vpn_not_authorized_error">کاربر به سرویس VPN اجازه نداد</string>
     <string name="vpn_start_error">نمی‌توان سرویس VPN اندروید را آغاز کرد</string>
     <string name="zip_export_error">نمی‌توان تونل‌ها را برون‎برد: %s</string>

--- a/ui/src/main/res/values-fi-rFI/strings.xml
+++ b/ui/src/main/res/values-fi-rFI/strings.xml
@@ -36,7 +36,7 @@
     <string name="config_not_found_error">Asetustiedostoa “%s” ei löydy</string>
     <string name="config_rename_error">Asetustiedostoa \"%s\" ei voi nimetä uudelleen</string>
     <string name="config_save_success">Asetustiedosto \"%s\" tallennettu onnistuneesti</string>
-    <string name="create_activity_title">Luo AmneziaWG Tunnel</string>
+    <string name="create_activity_title">Luo iDrugConnections Tunnel</string>
     <string name="dark_theme_title">Käytä tummaa teemaa</string>
     <string name="delete">Poista</string>
     <string name="tv_delete">Valitse poistettava tunneli</string>
@@ -58,9 +58,9 @@
     <string name="import_success">Tuotu ”%s”</string>
     <string name="key_contents_error">Virheellinen merkki avaimessa</string>
     <string name="key_length_error">Virheellinen avaimen pituus</string>
-    <string name="key_length_explanation_base64">: AmneziaWGin base64-avainten pituus on oltava 44 merkkiä (32 tavua)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG-avainten on oltava 32 tavua</string>
-    <string name="key_length_explanation_hex">: AmneziaWGin base64-avainten pituus on oltava 64 merkkiä (32 tavua)</string>
+    <string name="key_length_explanation_base64">: iDrugConnectionsin base64-avainten pituus on oltava 44 merkkiä (32 tavua)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections-avainten on oltava 32 tavua</string>
+    <string name="key_length_explanation_hex">: iDrugConnectionsin base64-avainten pituus on oltava 64 merkkiä (32 tavua)</string>
     <string name="listen_port">Kuuntele porttia</string>
     <string name="log_viewer_title">Loki</string>
     <string name="module_installer_error">Jokin meni pieleen. Yritä uudelleen</string>

--- a/ui/src/main/res/values-fr/strings.xml
+++ b/ui/src/main/res/values-fr/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Impossible de renommer le fichier de configuration « %s »</string>
     <string name="config_save_error">Impossible d’enregistrer la configuration pour « %1$s » : %2$s</string>
     <string name="config_save_success">Configuration enregistrée avec succès pour « %s »</string>
-    <string name="create_activity_title">Créer un tunnel AmneziaWG</string>
+    <string name="create_activity_title">Créer un tunnel iDrugConnections</string>
     <string name="create_bin_dir_error">Impossible de créer le répertoire binaire local</string>
     <string name="create_downloads_file_error">Impossible de créer le fichier dans le répertoire des téléchargements</string>
     <string name="create_empty">Créer à partir de zéro</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Mauvais caractères dans la clé</string>
     <string name="key_length_error">Longueur de la clé incorrecte</string>
-    <string name="key_length_explanation_base64">: Les clés base64 AmneziaWG doivent comporter 44 caractères (32 octets)</string>
-    <string name="key_length_explanation_binary">: Les clés AmneziaWG doivent comporter 32 octets</string>
-    <string name="key_length_explanation_hex">: Les clés hexadécimales AmneziaWG doivent comporter 64 caractères (32 octets)</string>
+    <string name="key_length_explanation_base64">: Les clés base64 iDrugConnections doivent comporter 44 caractères (32 octets)</string>
+    <string name="key_length_explanation_binary">: Les clés iDrugConnections doivent comporter 32 octets</string>
+    <string name="key_length_explanation_hex">: Les clés hexadécimales iDrugConnections doivent comporter 64 caractères (32 octets)</string>
     <string name="latest_handshake">Dernière liaison</string>
     <string name="latest_handshake_ago">Il y a %s</string>
     <string name="listen_port">Port d\'écoute</string>
     <string name="log_export_error">Impossible d\'exporter le journal : %s</string>
-    <string name="log_export_subject">Fichier journal d\'Android AmneziaWG</string>
+    <string name="log_export_subject">Fichier journal d\'Android iDrugConnections</string>
     <string name="log_export_success">Enregistré dans « %s »</string>
     <string name="log_export_title">Exporter le fichier journal</string>
     <string name="log_saver_activity_label">Enregistrer le journal</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">nombre</string>
     <string name="parse_error_reason">Impossible d\'analyser %1$s “%2$s”</string>
     <string name="peer">Pair</string>
-    <string name="permission_description">contrôler les tunnels AmneziaWG, activer et désactiver les tunnels à volonté, potentiellement détourner le trafic Internet</string>
-    <string name="permission_label">contrôler les tunnels AmneziaWG</string>
+    <string name="permission_description">contrôler les tunnels iDrugConnections, activer et désactiver les tunnels à volonté, potentiellement détourner le trafic Internet</string>
+    <string name="permission_label">contrôler les tunnels iDrugConnections</string>
     <string name="persistent_keepalive">Maintien de connexion permanente</string>
     <string name="pre_shared_key">Clé pré-partagée</string>
     <string name="pre_shared_key_enabled">activée</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">L\'interpréteur de commande n\'a pas pu démarrer : %d</string>
     <string name="success_application_will_restart">Succès. L\'application va redémarrer maintenant…</string>
     <string name="toggle_all">Tout basculer</string>
-    <string name="toggle_error">Erreur lors de l\'activation du tunnel AmneziaWG : %s</string>
+    <string name="toggle_error">Erreur lors de l\'activation du tunnel iDrugConnections : %s</string>
     <string name="tools_installer_already">awg et awg-quick sont déjà installés</string>
     <string name="tools_installer_failure">Impossible d\'installer les outils en ligne de commande (pas de root?)</string>
     <string name="tools_installer_initial">Installer les outils optionnels pour le script</string>
@@ -232,7 +232,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Vérification de la version %s du backend</string>
     <string name="version_summary_unknown">Version %s inconnue</string>
-    <string name="version_title">AmneziaWG pour Android v%s</string>
+    <string name="version_title">iDrugConnections pour Android v%s</string>
     <string name="vpn_not_authorized_error">Service VPN non autorisé par l\'utilisateur</string>
     <string name="vpn_start_error">Impossible de démarrer le service VPN Android</string>
     <string name="zip_export_error">Impossible d\'exporter les tunnels : %s</string>

--- a/ui/src/main/res/values-hi-rIN/strings.xml
+++ b/ui/src/main/res/values-hi-rIN/strings.xml
@@ -125,7 +125,7 @@
     <string name="key_length_explanation_hex">: वायरगार्ड हेक्स कीज़ 64 अक्षरों की होनी चाहिए (32 बाइट्स)</string>
     <string name="listen_port">पोर्ट सूने</string>
     <string name="log_export_error">लॉग निर्यात करने में असमर्थ: %s</string>
-    <string name="log_export_subject">AmneziaWG एंड्राइड लॉग फ़ाइल</string>
+    <string name="log_export_subject">iDrugConnections एंड्राइड लॉग फ़ाइल</string>
     <string name="log_export_success">“%s” में सहेजा गया</string>
     <string name="log_export_title">लॉग फ़ाइल निर्यात करें</string>
     <string name="log_saver_activity_label">लॉग सहेजे</string>
@@ -205,7 +205,7 @@
     <string name="version_summary">%1$s बैकएंड %2$s</string>
     <string name="version_summary_checking">%s बैकएंड संस्करण की जाँच कर रहा है</string>
     <string name="version_summary_unknown">अज्ञात %s संस्करण</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">वीपीएन सेवा उपयोगकर्ता द्वारा अधिकृत नहीं है</string>
     <string name="vpn_start_error">एंड्रॉयड वीपीएन सेवा प्रारंभ करने में असमर्थ</string>
     <string name="zip_export_error">टनल का निर्यात करने में असमर्थ: %s</string>

--- a/ui/src/main/res/values-hi/strings.xml
+++ b/ui/src/main/res/values-hi/strings.xml
@@ -27,7 +27,7 @@
     <string name="add_peer">पीयर जोड़ें</string>
     <string name="addresses">एड्रेससैस</string>
     <string name="allowed_ips">अनुमत आईपी</string>
-    <string name="app_name">AmneziaWG</string>
+    <string name="app_name">iDrugConnections</string>
     <string name="bad_config_context">%1$s\'s %2$s</string>
     <string name="bad_config_context_top_level">%s</string>
     <string name="bad_config_error">%1$s in %2$s</string>
@@ -164,7 +164,7 @@
     <string name="version_summary">%1$s बैकएंड %2$s</string>
     <string name="version_summary_checking">%s बैकएंड संस्करण की जाँच कर रहा है</string>
     <string name="version_summary_unknown">अज्ञात %s संस्करण</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">वीपीएन सेवा उपयोगकर्ता द्वारा अधिकृत नहीं है</string>
     <string name="vpn_start_error">एंड्रॉयड वीपीएन सेवा प्रारंभ करने में असमर्थ</string>
     <string name="zip_export_error">टनल का निर्यात करने में असमर्थ: %s</string>

--- a/ui/src/main/res/values-in/strings.xml
+++ b/ui/src/main/res/values-in/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">Tidak bisa mengganti nama konfigurasi “%s”</string>
     <string name="config_save_error">Konfigurasi “%1$s”: %2$s tidak bisa disimpan</string>
     <string name="config_save_success">Konfigurasi “%s” berhasil disimpan</string>
-    <string name="create_activity_title">Buat tunel AmneziaWG</string>
+    <string name="create_activity_title">Buat tunel iDrugConnections</string>
     <string name="create_bin_dir_error">Tidak dapat membuat direktori biner lokal</string>
     <string name="create_downloads_file_error">Tidak dapat membuat file di direktori download</string>
     <string name="create_empty">Buat dari awal</string>
@@ -119,12 +119,12 @@
     <string name="interface_title">Antarmuka</string>
     <string name="key_contents_error">Karakter buruk pada kunci</string>
     <string name="key_length_error">Panjang kunci salah</string>
-    <string name="key_length_explanation_base64">: Kunci AmneziaWG base64 harus terdiri dari 44 karakter (32 bit)</string>
-    <string name="key_length_explanation_binary">: Kunci AmneziaWG harus terdiri dari 32 bit</string>
-    <string name="key_length_explanation_hex">: Kunci hex AmneziaWG Harus terdiri dari 64 karakter (32 bit)</string>
+    <string name="key_length_explanation_base64">: Kunci iDrugConnections base64 harus terdiri dari 44 karakter (32 bit)</string>
+    <string name="key_length_explanation_binary">: Kunci iDrugConnections harus terdiri dari 32 bit</string>
+    <string name="key_length_explanation_hex">: Kunci hex iDrugConnections Harus terdiri dari 64 karakter (32 bit)</string>
     <string name="listen_port">Isi port</string>
     <string name="log_export_error">Log tidak bisa diekspor: %s</string>
-    <string name="log_export_subject">Berkas Log AmneziaWG Android</string>
+    <string name="log_export_subject">Berkas Log iDrugConnections Android</string>
     <string name="log_export_success">Simpan ke “%s”</string>
     <string name="log_export_title">Ekspor file log</string>
     <string name="log_saver_activity_label">Simpan log</string>
@@ -157,8 +157,8 @@
     <string name="parse_error_integer">angka</string>
     <string name="parse_error_reason">%1$s “%2$s” Tidak dapat diuraikan</string>
     <string name="peer">Rekan</string>
-    <string name="permission_description">mengontrol terowongan AmneziaWG, mengaktifkan dan menonaktifkannya sesuka hati, berpotensi salah melalu lintas Internet</string>
-    <string name="permission_label">Kontrol tunel AmneziaWG</string>
+    <string name="permission_description">mengontrol terowongan iDrugConnections, mengaktifkan dan menonaktifkannya sesuka hati, berpotensi salah melalu lintas Internet</string>
+    <string name="permission_label">Kontrol tunel iDrugConnections</string>
     <string name="persistent_keepalive">Keepalive persisten</string>
     <string name="pre_shared_key">Kunci Pra-bersama</string>
     <string name="pre_shared_key_enabled">diaktifkan</string>
@@ -176,7 +176,7 @@
     <string name="shell_start_error">Gagal memulai shell: %d</string>
     <string name="success_application_will_restart">Berhasil. Sekarang aplikasi akan memulai ulang…</string>
     <string name="toggle_all">Matikan semua</string>
-    <string name="toggle_error">Tunel AmneziaWG %s gagal dialihkan</string>
+    <string name="toggle_error">Tunel iDrugConnections %s gagal dialihkan</string>
     <string name="tools_installer_already">awg and awg-quick sudah terpasang</string>
     <string name="tools_installer_failure">Tidak dapat memasang alat command-line (tidak root?)</string>
     <string name="tools_installer_initial">Pasang alat opsional untuk skrip</string>
@@ -211,7 +211,7 @@
     <string name="version_summary">%1$s dengan v%2$s</string>
     <string name="version_summary_checking">Mengecek versi backend %s</string>
     <string name="version_summary_unknown">Versi %s Tidak diketahui</string>
-    <string name="version_title">AmneziaWG untuk Android v%s</string>
+    <string name="version_title">iDrugConnections untuk Android v%s</string>
     <string name="vpn_not_authorized_error">Layanan VPN tidak diotorisasi oleh pengguna</string>
     <string name="vpn_start_error">Tidak dapat memulai layanan VPN Android</string>
     <string name="zip_export_error">Tunel %s tidak bisa diekspor</string>

--- a/ui/src/main/res/values-it/strings.xml
+++ b/ui/src/main/res/values-it/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Impossibile rinominare il file di configurazione “%s”</string>
     <string name="config_save_error">Impossibile salvare la configurazione per “%1$s”: %2$s</string>
     <string name="config_save_success">Configurazione per “%s” salvata correttamente</string>
-    <string name="create_activity_title">Crea un tunnel AmneziaWG</string>
+    <string name="create_activity_title">Crea un tunnel iDrugConnections</string>
     <string name="create_bin_dir_error">Impossibile creare cartella locale binari</string>
     <string name="create_downloads_file_error">Impossibile creare il file nella cartella di download</string>
     <string name="create_empty">Crea da zero</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Interfaccia</string>
     <string name="key_contents_error">Caratteri non validi nella chiave</string>
     <string name="key_length_error">Lunghezza non valida della chiave</string>
-    <string name="key_length_explanation_base64">: le chiavi base64 di AmneziaWG devono essere di 44 caratteri (32 byte)</string>
-    <string name="key_length_explanation_binary">: le chiavi di AmneziaWG devono essere di 32 byte</string>
-    <string name="key_length_explanation_hex">: le chiavi esadecimali di AmneziaWG devono essere di 64 caratteri (32 byte)</string>
+    <string name="key_length_explanation_base64">: le chiavi base64 di iDrugConnections devono essere di 44 caratteri (32 byte)</string>
+    <string name="key_length_explanation_binary">: le chiavi di iDrugConnections devono essere di 32 byte</string>
+    <string name="key_length_explanation_hex">: le chiavi esadecimali di iDrugConnections devono essere di 64 caratteri (32 byte)</string>
     <string name="latest_handshake">Ultima negoziazione</string>
     <string name="latest_handshake_ago">%s fa</string>
     <string name="listen_port">Porta in ascolto</string>
     <string name="log_export_error">Impossibile esportare il log: %s</string>
-    <string name="log_export_subject">File di log AmneziaWG Android</string>
+    <string name="log_export_subject">File di log iDrugConnections Android</string>
     <string name="log_export_success">Salvato in “%s”</string>
     <string name="log_export_title">Esporta file di log</string>
     <string name="log_saver_activity_label">Salva log</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">numero</string>
     <string name="parse_error_reason">Impossibile analizzare %1$s “%2$s”</string>
     <string name="peer">Peer</string>
-    <string name="permission_description">controllare i tunnel AmneziaWG, abilitando e disabilitando i tunnel a piacimento, potenzialmente dirottando il traffico Internet</string>
-    <string name="permission_label">controlla tunnel AmneziaWG</string>
+    <string name="permission_description">controllare i tunnel iDrugConnections, abilitando e disabilitando i tunnel a piacimento, potenzialmente dirottando il traffico Internet</string>
+    <string name="permission_label">controlla tunnel iDrugConnections</string>
     <string name="persistent_keepalive">Tieni sempre attivo</string>
     <string name="pre_shared_key">Chiave condivisa (PSK)</string>
     <string name="pre_shared_key_enabled">abilitata</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">Avvio della shell non riuscito: %d</string>
     <string name="success_application_will_restart">Successo. L\'applicazione si riavvierà…</string>
     <string name="toggle_all">Inverti tutto</string>
-    <string name="toggle_error">Errore di commutazione tunnel AmneziaWG: %s</string>
+    <string name="toggle_error">Errore di commutazione tunnel iDrugConnections: %s</string>
     <string name="tools_installer_already">awg e awg-quick sono già installati</string>
     <string name="tools_installer_failure">Impossibile installare strumenti di riga di comando (non root?)</string>
     <string name="tools_installer_initial">Installa strumenti facoltativi per script</string>
@@ -232,7 +232,7 @@
     <string name="version_summary">Backend %1$s %2$s</string>
     <string name="version_summary_checking">Controllo versione backend %s</string>
     <string name="version_summary_unknown">Versione %s sconosciuta</string>
-    <string name="version_title">AmneziaWG per Android v%s</string>
+    <string name="version_title">iDrugConnections per Android v%s</string>
     <string name="vpn_not_authorized_error">Servizio VPN non autorizzato dall\'utente</string>
     <string name="vpn_start_error">Impossibile avviare il servizio VPN di Android</string>
     <string name="zip_export_error">Impossibile esportare i tunnel: %s</string>

--- a/ui/src/main/res/values-ja/strings.xml
+++ b/ui/src/main/res/values-ja/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">設定ファイル \"%s\" の名前を変更できません</string>
     <string name="config_save_error">“%1$s” の設定を保存できません: %2$s</string>
     <string name="config_save_success">\"%s\" の設定を保存しました</string>
-    <string name="create_activity_title">AmneziaWG トンネルの作成</string>
+    <string name="create_activity_title">iDrugConnections トンネルの作成</string>
     <string name="create_bin_dir_error">ローカルバイナリディレクトリを作成できません</string>
     <string name="create_downloads_file_error">ダウンロードディレクトリにファイルを作成できません</string>
     <string name="create_empty">空の状態から作成</string>
@@ -120,14 +120,14 @@
     <string name="interface_title">インターフェース</string>
     <string name="key_contents_error">鍵に不正な文字があります</string>
     <string name="key_length_error">鍵の長さが不正です</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 鍵は44文字 (32バイト) でなければなりません</string>
-    <string name="key_length_explanation_binary">: AmneziaWG 鍵は32バイトでなければなりません</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex 鍵は64文字 (32バイト) でなければなりません</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 鍵は44文字 (32バイト) でなければなりません</string>
+    <string name="key_length_explanation_binary">: iDrugConnections 鍵は32バイトでなければなりません</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex 鍵は64文字 (32バイト) でなければなりません</string>
     <string name="latest_handshake">直近のハンドシェイク</string>
     <string name="latest_handshake_ago">%s 前</string>
     <string name="listen_port">Listen ポート</string>
     <string name="log_export_error">ログをエクスポートできません: %s</string>
-    <string name="log_export_subject">AmneziaWG Android ログファイル</string>
+    <string name="log_export_subject">iDrugConnections Android ログファイル</string>
     <string name="log_export_success">“%s” に保存しました</string>
     <string name="log_export_title">ログのエクスポート</string>
     <string name="log_saver_activity_label">ログの保存</string>
@@ -160,8 +160,8 @@
     <string name="parse_error_integer">数値</string>
     <string name="parse_error_reason">%1$s の内容を解読できません “%2$s”</string>
     <string name="peer">ピア</string>
-    <string name="permission_description">AmneziaWG トンネルを制御し、自由に有効化/無効化できますが、インターネット向けトラフィックが意図しない方向に流れる可能性があります</string>
-    <string name="permission_label">AmneziaWG トンネルの制御</string>
+    <string name="permission_description">iDrugConnections トンネルを制御し、自由に有効化/無効化できますが、インターネット向けトラフィックが意図しない方向に流れる可能性があります</string>
+    <string name="permission_label">iDrugConnections トンネルの制御</string>
     <string name="persistent_keepalive">持続的キープアライブ</string>
     <string name="pre_shared_key">事前共有鍵</string>
     <string name="pre_shared_key_enabled">有効</string>
@@ -183,7 +183,7 @@
     <string name="shell_start_error">シェルの起動に失敗しました: %d</string>
     <string name="success_application_will_restart">成功。アプリケーションは再起動します…</string>
     <string name="toggle_all">すべての状態を切り替え</string>
-    <string name="toggle_error">AmneziaWG トンネルの状態切り替え時にエラー: %s</string>
+    <string name="toggle_error">iDrugConnections トンネルの状態切り替え時にエラー: %s</string>
     <string name="tools_installer_already">awg および awg-quick はインストール済みです</string>
     <string name="tools_installer_failure">コマンドラインツールをインストールできません(root権限がない？)</string>
     <string name="tools_installer_initial">スクリプティングのためのオプションツールのインストール</string>
@@ -219,7 +219,7 @@
     <string name="version_summary">%1$s バックエンド %2$s</string>
     <string name="version_summary_checking">%s バックエンドのバージョンを確認中</string>
     <string name="version_summary_unknown">未知の %s バージョン</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">VPN サービスはユーザによって認証されていません</string>
     <string name="vpn_start_error">Android VPN サービスを開始できません</string>
     <string name="zip_export_error">トンネル設定をエクスポートできません: %s</string>

--- a/ui/src/main/res/values-ko-rKR/strings.xml
+++ b/ui/src/main/res/values-ko-rKR/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">설정파일 \"%s\"의 이름을 변경할 수 없음</string>
     <string name="config_save_error">\"%1$s\"에 대한 설정을 저장할 수 없음: %2$s</string>
     <string name="config_save_success">\"%s\"에 대한 설정을 성공적으로 저장했습니다</string>
-    <string name="create_activity_title">AmneziaWG 터널 만들기</string>
+    <string name="create_activity_title">iDrugConnections 터널 만들기</string>
     <string name="create_bin_dir_error">로컬 바이너리 디렉터리를 만들 수 없음</string>
     <string name="create_downloads_file_error">다운로드 디렉토리에 파일을 만들 수 없음</string>
     <string name="create_empty">직접 만들기</string>
@@ -119,12 +119,12 @@
     <string name="interface_title">인터페이스</string>
     <string name="key_contents_error">키에서 잘못된 글자 발견</string>
     <string name="key_length_error">잘못된 키 길이</string>
-    <string name="key_length_explanation_base64">: AmneziaWG의 base64 키는 반드시 44 글자(32 바이트)임</string>
-    <string name="key_length_explanation_binary">: AmneziaWG의 키는 반드시 32 바이트임</string>
-    <string name="key_length_explanation_hex">: AmneziaWG의 16진수 키는 반드시 64 글자(32 바이트)임</string>
+    <string name="key_length_explanation_base64">: iDrugConnections의 base64 키는 반드시 44 글자(32 바이트)임</string>
+    <string name="key_length_explanation_binary">: iDrugConnections의 키는 반드시 32 바이트임</string>
+    <string name="key_length_explanation_hex">: iDrugConnections의 16진수 키는 반드시 64 글자(32 바이트)임</string>
     <string name="listen_port">수신 대기 포트</string>
     <string name="log_export_error">로그를 내보낼 수 없음: %s</string>
-    <string name="log_export_subject">AmneziaWG 안드로이드 로그 파일</string>
+    <string name="log_export_subject">iDrugConnections 안드로이드 로그 파일</string>
     <string name="log_export_success">“%s”에 저장됨</string>
     <string name="log_export_title">로그 파일 내보내기</string>
     <string name="log_saver_activity_label">로그를 저장하기</string>
@@ -157,8 +157,8 @@
     <string name="parse_error_integer">횟수</string>
     <string name="parse_error_reason">%1$s을 파싱할 수 없음: “%2$s”</string>
     <string name="peer">피어</string>
-    <string name="permission_description">마음대로 터널을 활성화 및 비활성화하는 등 AmneziaWG 터널을 제어하면, 인터넷 트래픽을 잘못 전달할 위험이 있음</string>
-    <string name="permission_label">AmneziaWG 터널 제어</string>
+    <string name="permission_description">마음대로 터널을 활성화 및 비활성화하는 등 iDrugConnections 터널을 제어하면, 인터넷 트래픽을 잘못 전달할 위험이 있음</string>
+    <string name="permission_label">iDrugConnections 터널 제어</string>
     <string name="persistent_keepalive">Persistent keepalive</string>
     <string name="pre_shared_key">사전 공유 키</string>
     <string name="pre_shared_key_enabled">활성화됨</string>
@@ -176,7 +176,7 @@
     <string name="shell_start_error">쉘이 실행 실패함: %d</string>
     <string name="success_application_will_restart">성공. 앱이 곧 재시작됨…</string>
     <string name="toggle_all">모두 반전</string>
-    <string name="toggle_error">AmneziaWG 터널 토글링 오류: %s</string>
+    <string name="toggle_error">iDrugConnections 터널 토글링 오류: %s</string>
     <string name="tools_installer_already">awg와 awg-quick 모두 이미 설치되었음</string>
     <string name="tools_installer_failure">커맨드라인 도구 설치 불가 (루트 권한 필요)</string>
     <string name="tools_installer_initial">스크립팅에 필요한 선택적 도구 설치하기</string>
@@ -209,7 +209,7 @@
     <string name="unknown_error">알 수 없는 오류</string>
     <string name="version_summary_checking">%s 백엔드 버전 확인 중</string>
     <string name="version_summary_unknown">알 수 없는 버전: %s</string>
-    <string name="version_title">AmneziaWG for 안드로이드 v%s</string>
+    <string name="version_title">iDrugConnections for 안드로이드 v%s</string>
     <string name="vpn_not_authorized_error">VPN 서비스는 사용자에 의해 승인되지 않았음</string>
     <string name="vpn_start_error">안드로이드 VPN 서비스를 시작할 수 없음</string>
     <string name="zip_export_error">터널을 내보낼 수 없음: %s</string>

--- a/ui/src/main/res/values-night/themes.xml
+++ b/ui/src/main/res/values-night/themes.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AmneziaWgTheme" parent="Theme.Material3.Dark">
+    <style name="iDrugConnectionsTheme" parent="Theme.Material3.Dark">
         <item name="colorPrimary">@color/md_theme_dark_primary</item>
         <item name="colorOnPrimary">@color/md_theme_dark_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_dark_primaryContainer</item>

--- a/ui/src/main/res/values-nl-rNL/strings.xml
+++ b/ui/src/main/res/values-nl-rNL/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Kan configuratiebestand \"%s\" \" niet hernoemen</string>
     <string name="config_save_error">Kan de configuratie voor \"%1$s\" niet opslaan: %2$s</string>
     <string name="config_save_success">Configuratie succesvol opgeslagen voor \"%s\"</string>
-    <string name="create_activity_title">AmneziaWG tunnel aanmaken</string>
+    <string name="create_activity_title">iDrugConnections tunnel aanmaken</string>
     <string name="create_bin_dir_error">Kan geen lokale \'bin\' map aanmaken</string>
     <string name="create_downloads_file_error">Kan bestand niet maken in downloadmap</string>
     <string name="create_empty">Begin met lege configuratie</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Slechte tekens in de veld</string>
     <string name="key_length_error">Onjuiste sleutellengte</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 sleutels moeten 44 tekens zijn (32 bytes)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG sleutels moeten 32 bytes zijn</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex sleutels moeten 64 tekens zijn (32 bytes)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 sleutels moeten 44 tekens zijn (32 bytes)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections sleutels moeten 32 bytes zijn</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex sleutels moeten 64 tekens zijn (32 bytes)</string>
     <string name="latest_handshake">Recentste uitwisseling</string>
     <string name="latest_handshake_ago">%s geleden</string>
     <string name="listen_port">Luister op poort</string>
     <string name="log_export_error">Kan logboek niet exporteren: %s</string>
-    <string name="log_export_subject">AmneziaWG Android logbestand</string>
+    <string name="log_export_subject">iDrugConnections Android logbestand</string>
     <string name="log_export_success">Opgeslagen in \"%s\"</string>
     <string name="log_export_title">Exporteer logboek naar bestand</string>
     <string name="log_saver_activity_label">Logboek opslaan</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">nummer</string>
     <string name="parse_error_reason">Kan %1$s%2$s niet parsen</string>
     <string name="peer">Peer</string>
-    <string name="permission_description">beheer AmneziaWG tunnels, zet tunnels naar keuze aan en uit, en misleid mogelijk het Internetverkeer</string>
-    <string name="permission_label">AmneziaWG tunnels beheren</string>
+    <string name="permission_description">beheer iDrugConnections tunnels, zet tunnels naar keuze aan en uit, en misleid mogelijk het Internetverkeer</string>
+    <string name="permission_label">iDrugConnections tunnels beheren</string>
     <string name="persistent_keepalive">Voortdurende verbindingstest</string>
     <string name="pre_shared_key">Gedeelde sleutel</string>
     <string name="pre_shared_key_enabled">ingeschakeld</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">Shell kon niet starten: %d</string>
     <string name="success_application_will_restart">Succes. De toepassing zal nu herstarten…</string>
     <string name="toggle_all">Alles wisselen</string>
-    <string name="toggle_error">Fout bij omschakelen AmneziaWG tunnel: %s</string>
+    <string name="toggle_error">Fout bij omschakelen iDrugConnections tunnel: %s</string>
     <string name="tools_installer_already">awg and awg-quick zijn al geïnstalleerd</string>
     <string name="tools_installer_failure">Kan de command-line tools niet installeren (geen root?)</string>
     <string name="tools_installer_initial">Optionele tools voor scripts installeren</string>
@@ -217,7 +217,7 @@
     <string name="type_name_go_userspace">Go userspace</string>
     <string name="type_name_kernel_module">Kernel module</string>
     <string name="unknown_error">Onbekende fout</string>
-    <string name="version_title">AmneziaWG voor Android v%s</string>
+    <string name="version_title">iDrugConnections voor Android v%s</string>
     <string name="zip_export_summary">Zip-bestand wordt opgeslagen in de downloadmap</string>
     <string name="zip_export_title">Exporteer tunnels naar zip-bestand</string>
     <string name="biometric_prompt_zip_exporter_title">Authenticeer om de tunnel configuratie te exporteren</string>

--- a/ui/src/main/res/values-no-rNO/strings.xml
+++ b/ui/src/main/res/values-no-rNO/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Kan ikke endre navn på konfigurasjonsfilen «%s»</string>
     <string name="config_save_error">Kan ikke lagre konfigurasjonen for “%1$s”: %2$s</string>
     <string name="config_save_success">Vellykket lagring av konfigurasjon for «%s»</string>
-    <string name="create_activity_title">Opprett AmneziaWG tunnel</string>
+    <string name="create_activity_title">Opprett iDrugConnections tunnel</string>
     <string name="create_bin_dir_error">Kan ikke opprette lokal binærmappe</string>
     <string name="create_downloads_file_error">Kan ikke opprette fil i nedlastingsmappen</string>
     <string name="create_empty">Lag fra begynnelsen</string>
@@ -133,12 +133,12 @@
     <string name="interface_title">Grensesnitt</string>
     <string name="key_contents_error">Ugyldig tegn i nøkkel</string>
     <string name="key_length_error">Ugyldig nøkkellengde</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64-nøkler må være 44 tegn (32 byte)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG nøkler må være 32 byte</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex-nøkler må være 64 tegn (32 byte)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64-nøkler må være 44 tegn (32 byte)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections nøkler må være 32 byte</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex-nøkler må være 64 tegn (32 byte)</string>
     <string name="listen_port">Lytt på port</string>
     <string name="log_export_error">Kan ikke eksportere logg: %s</string>
-    <string name="log_export_subject">AmneziaWG Android loggfil</string>
+    <string name="log_export_subject">iDrugConnections Android loggfil</string>
     <string name="log_export_success">Lagret til «%s»</string>
     <string name="log_export_title">Eksporter loggfil</string>
     <string name="log_saver_activity_label">Lagre logg</string>
@@ -171,8 +171,8 @@
     <string name="parse_error_integer">nummer</string>
     <string name="parse_error_reason">Kan ikke tolke %1$s “%2$s”</string>
     <string name="peer">Partner</string>
-    <string name="permission_description">kontroller AmneziaWG-tunneler, aktiver og deaktiver dem. Kan potensielt ta ned internett-tilgangen</string>
-    <string name="permission_label">kontroller AmneziaWG-tunneler</string>
+    <string name="permission_description">kontroller iDrugConnections-tunneler, aktiver og deaktiver dem. Kan potensielt ta ned internett-tilgangen</string>
+    <string name="permission_label">kontroller iDrugConnections-tunneler</string>
     <string name="persistent_keepalive">Send keepalive-pakker</string>
     <string name="pre_shared_key">Forhåndsdelt nøkkel</string>
     <string name="pre_shared_key_enabled">aktivert</string>
@@ -190,7 +190,7 @@
     <string name="shell_start_error">Skallet klarte ikke å starte: %d</string>
     <string name="success_application_will_restart">Suksess. Programmet vil nå starte på nytt…</string>
     <string name="toggle_all">Toggle alle</string>
-    <string name="toggle_error">Feil under toggling av AmneziaWG tunnel: %s</string>
+    <string name="toggle_error">Feil under toggling av iDrugConnections tunnel: %s</string>
     <string name="tools_installer_already">awg og awg-quick er allerede installert</string>
     <string name="tools_installer_failure">Kunne ikke installere kommandolinjeverktøy (ingen root-tilgang?)</string>
     <string name="tools_installer_initial">Installer valgfrie verktøy for skripting</string>
@@ -226,7 +226,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Sjekker %s backend versjon</string>
     <string name="version_summary_unknown">Ukjent %s versjon</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">VPN-tjeneste er ikke autorisert av bruker</string>
     <string name="vpn_start_error">Kan ikke starte Android VPN-tjenesten</string>
     <string name="zip_export_error">Kan ikke eksportere tunneler: %s</string>

--- a/ui/src/main/res/values-pa-rIN/strings.xml
+++ b/ui/src/main/res/values-pa-rIN/strings.xml
@@ -129,9 +129,9 @@
     <string name="interface_title">ਇੰਟਰਫੇਸ</string>
     <string name="key_contents_error">ਕੁੰਜੀ ਵਿੱਚ ਗ਼ਲਤ ਅੱਖਰ</string>
     <string name="key_length_error">ਗ਼ਲਤ ਕੁੰਜੀ ਦੀ ਲੰਬਾਈ</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 ਕੁੰਜੀਆਂ ਵਿੱਚ 44 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ (32 ਬਾਈਟ)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG ਕੁੰਜੀਆਂ 32 ਬਾਈਟ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ</string>
-    <string name="key_length_explanation_hex">: AmneziaWG ਹੈਕਸਾ ਕੁੰਜੀਆਂ ਵਿੱਚ 64 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ (32 ਬਾਈਟ)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 ਕੁੰਜੀਆਂ ਵਿੱਚ 44 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ (32 ਬਾਈਟ)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections ਕੁੰਜੀਆਂ 32 ਬਾਈਟ ਹੋਣੀਆਂ ਚਾਹੀਦੀਆਂ ਹਨ</string>
+    <string name="key_length_explanation_hex">: iDrugConnections ਹੈਕਸਾ ਕੁੰਜੀਆਂ ਵਿੱਚ 64 ਅੱਖਰ ਹੋਣੇ ਚਾਹੀਦੇ ਹਨ (32 ਬਾਈਟ)</string>
     <string name="listen_port">ਸੁਣਨ ਵਾਲੀ ਪੋਰਟ</string>
     <string name="log_export_error">ਲਾਗ ਐਕਸਪੋਰਟ ਕਰਨ ਲਈ ਅਸਮਰੱਥ: %s</string>
     <string name="log_export_subject">ਵਾਇਰਗਾਰਡ ਐਂਡਰਾਈਡ ਲਾਗ ਫ਼ਾਇਲ</string>
@@ -219,7 +219,7 @@
     <string name="unknown_error">ਅਣਪਛਾਤੀ ਗਲਤੀ</string>
     <string name="version_summary_checking">%s ਬੈਕਐਂਡ ਵਰਜ਼ਨ ਦੀ ਜਾਂਚ ਕੀਤੀ ਜਾ ਰਹੀ ਹੈ</string>
     <string name="version_summary_unknown">ਅਣਪਛਾਤਾ %s ਵਰਜਨ</string>
-    <string name="version_title">Android ਲਈ AmneziaWG v%s</string>
+    <string name="version_title">Android ਲਈ iDrugConnections v%s</string>
     <string name="vpn_not_authorized_error">VPN ਸੇਵਾ ਨੂੰ ਵਰਤੋਂਕਾਰ ਨੇ ਪਰਮਾਣਿਤ ਨਹੀਂ ਕੀਤਾ</string>
     <string name="vpn_start_error">ਐਂਡਰਾਈਡ VPN ਸੇਵਾ ਸ਼ੁਰੂ ਕਰਨ ਲਈ ਅਸਮਰੱਥ</string>
     <string name="zip_export_error">ਟਨਲਾਂ ਐਕਸਪੋਰਟ ਕਰਨ ਲਈ ਅਸਮਰੱਥ: %s</string>

--- a/ui/src/main/res/values-pl-rPL/strings.xml
+++ b/ui/src/main/res/values-pl-rPL/strings.xml
@@ -115,7 +115,7 @@
     <string name="config_rename_error">Nie można zmienić nazwy pliku konfiguracyjnego „%s”</string>
     <string name="config_save_error">Nie można zapisać konfiguracji dla „%1$s”: %2$s</string>
     <string name="config_save_success">Pomyślnie zapisano konfigurację dla „%s”</string>
-    <string name="create_activity_title">Utwórz tunel AmneziaWG</string>
+    <string name="create_activity_title">Utwórz tunel iDrugConnections</string>
     <string name="create_bin_dir_error">Nie można utworzyć lokalnego folderu dla plików wykonywalnych</string>
     <string name="create_downloads_file_error">Nie można utworzyć pliku w folderze pobierania</string>
     <string name="create_empty">Utwórz ręcznie</string>
@@ -158,12 +158,12 @@
     <string name="interface_title">Interfejs</string>
     <string name="key_contents_error">Nieprawidłowe znaki w kluczu</string>
     <string name="key_length_error">Nieprawidłowa długość klucza</string>
-    <string name="key_length_explanation_base64">: Klucze Base64 AmneziaWG-a muszą mieć długość 44 znaków (32 bajty)</string>
-    <string name="key_length_explanation_binary">: Klucze AmneziaWG-a muszą mieć wielkość 32 bajtów</string>
-    <string name="key_length_explanation_hex">: Klucze Hex AmneziaWG-a muszą mieć długość 64 znaków (32 bajty)</string>
+    <string name="key_length_explanation_base64">: Klucze Base64 iDrugConnections-a muszą mieć długość 44 znaków (32 bajty)</string>
+    <string name="key_length_explanation_binary">: Klucze iDrugConnections-a muszą mieć wielkość 32 bajtów</string>
+    <string name="key_length_explanation_hex">: Klucze Hex iDrugConnections-a muszą mieć długość 64 znaków (32 bajty)</string>
     <string name="listen_port">Port nasłuchu</string>
     <string name="log_export_error">Nie można wyeksportować logu: %s</string>
-    <string name="log_export_subject">Plik logu programu AmneziaWG dla systemu Android</string>
+    <string name="log_export_subject">Plik logu programu iDrugConnections dla systemu Android</string>
     <string name="log_export_success">Zapisano w „%s”</string>
     <string name="log_export_title">Wyeksportuj plik logu</string>
     <string name="log_saver_activity_label">Zapisz log</string>
@@ -196,8 +196,8 @@
     <string name="parse_error_integer">liczba</string>
     <string name="parse_error_reason">Nie można przetworzyć %1$s „%2$s”</string>
     <string name="peer">Klient</string>
-    <string name="permission_description">kontrolowanie tuneli AmneziaWG, włączanie i wyłączanie tuneli, potencjalnie błędne kierowanie ruchem internetowym</string>
-    <string name="permission_label">sterowanie tunelami AmneziaWG</string>
+    <string name="permission_description">kontrolowanie tuneli iDrugConnections, włączanie i wyłączanie tuneli, potencjalnie błędne kierowanie ruchem internetowym</string>
+    <string name="permission_label">sterowanie tunelami iDrugConnections</string>
     <string name="persistent_keepalive">Utrzymanie połączenia</string>
     <string name="pre_shared_key">Klucz wstępnie udostępniony</string>
     <string name="pre_shared_key_enabled">włączone</string>
@@ -215,7 +215,7 @@
     <string name="shell_start_error">Nie udało się uruchomić powłoki: %d</string>
     <string name="success_application_will_restart">Ukończono pomyślnie. Aplikacja zostanie uruchomiona ponownie…</string>
     <string name="toggle_all">Przełącz wszystkie</string>
-    <string name="toggle_error">Błąd podczas przełączania tunelu AmneziaWG: %s</string>
+    <string name="toggle_error">Błąd podczas przełączania tunelu iDrugConnections: %s</string>
     <string name="tools_installer_already">Narzędzia awg i awg-quick są już zainstalowane</string>
     <string name="tools_installer_failure">Nie można zainstalować narzędzi wiersza poleceń (brak root-a?)</string>
     <string name="tools_installer_initial">Zainstaluj opcjonalne narzędzia do tworzenia skryptów</string>
@@ -250,7 +250,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Sprawdzanie wersji implementacji: %s</string>
     <string name="version_summary_unknown">Nieznana wersja %s</string>
-    <string name="version_title">AmneziaWG dla systemu Android v%s</string>
+    <string name="version_title">iDrugConnections dla systemu Android v%s</string>
     <string name="vpn_not_authorized_error">Usługa VPN nie została autoryzowana przez użytkownika</string>
     <string name="vpn_start_error">Nie można uruchomić usługi VPN systemu Android</string>
     <string name="zip_export_error">Nie można wyeksportować tuneli: %s</string>

--- a/ui/src/main/res/values-pt-rBR/strings.xml
+++ b/ui/src/main/res/values-pt-rBR/strings.xml
@@ -65,7 +65,7 @@
     <string name="config_rename_error">Não é possível renomear o arquivo de configuração “%s”</string>
     <string name="config_save_error">Não pode salvar a configuração para \"%1$s\": %2$s</string>
     <string name="config_save_success">Configuração salva com sucesso para “%s”</string>
-    <string name="create_activity_title">Criar túnel AmneziaWG</string>
+    <string name="create_activity_title">Criar túnel iDrugConnections</string>
     <string name="create_bin_dir_error">Não é possível criar o diretório local do binário</string>
     <string name="create_downloads_file_error">Não é possível criar arquivo no diretório de downloads</string>
     <string name="create_empty">Criar do zero</string>
@@ -109,14 +109,14 @@
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Caracteres inválidos na chave</string>
     <string name="key_length_error">Chave com tamanho incorreto</string>
-    <string name="key_length_explanation_base64">: Chaves base64 do AmneziaWG devem ter 44 caracteres (32 bytes)</string>
-    <string name="key_length_explanation_binary">: Chaves do AmneziaWG devem ter 32 bytes</string>
-    <string name="key_length_explanation_hex">: Chaves hex do AmneziaWG devem ter 64 caracteres (32 bytes)</string>
+    <string name="key_length_explanation_base64">: Chaves base64 do iDrugConnections devem ter 44 caracteres (32 bytes)</string>
+    <string name="key_length_explanation_binary">: Chaves do iDrugConnections devem ter 32 bytes</string>
+    <string name="key_length_explanation_hex">: Chaves hex do iDrugConnections devem ter 64 caracteres (32 bytes)</string>
     <string name="latest_handshake">Último handshake</string>
     <string name="latest_handshake_ago">%s atrás</string>
     <string name="listen_port">Porta de escuta</string>
     <string name="log_export_error">Não foi possível exportar o log: %s</string>
-    <string name="log_export_subject">Arquivo de log do AmneziaWG Android</string>
+    <string name="log_export_subject">Arquivo de log do iDrugConnections Android</string>
     <string name="log_export_success">Salvo em “%s”</string>
     <string name="log_export_title">Exportar arquivo de log</string>
     <string name="log_saver_activity_label">Salvar log</string>
@@ -147,8 +147,8 @@
     <string name="parse_error_inet_endpoint">endpoint</string>
     <string name="parse_error_inet_network">Rede IP</string>
     <string name="parse_error_reason">Não é possível analisar %1$s “%2$s”</string>
-    <string name="permission_description">permite controlar túneis do AmneziaWG, ativando e desativando túneis a vontade, potencialmente desviando o tráfego na Internet</string>
-    <string name="permission_label">controlar túneis do AmneziaWG</string>
+    <string name="permission_description">permite controlar túneis do iDrugConnections, ativando e desativando túneis a vontade, potencialmente desviando o tráfego na Internet</string>
+    <string name="permission_label">controlar túneis do iDrugConnections</string>
     <string name="persistent_keepalive">Keepalive persistente</string>
     <string name="pre_shared_key">Chave pré-partilhada</string>
     <string name="pre_shared_key_enabled">ativo</string>
@@ -166,7 +166,7 @@
     <string name="shell_marker_count_error">Shell esperava 4 marcadores, mas recebeu apenas %d</string>
     <string name="shell_start_error">Shell falhou ao iniciar: %d</string>
     <string name="success_application_will_restart">Sucesso. O aplicativo irá reiniciar agora…</string>
-    <string name="toggle_error">Erro ao ativar o túnel do AmneziaWG: %s</string>
+    <string name="toggle_error">Erro ao ativar o túnel do iDrugConnections: %s</string>
     <string name="tools_installer_already">awg e awg-quick já estão instalados</string>
     <string name="tools_installer_failure">Não foi possível instalar ferramentas de linha de comando (sem root?)</string>
     <string name="tools_installer_initial">Instalar ferramentas opcionais para scripting</string>
@@ -199,7 +199,7 @@
     <string name="unknown_error">Erro desconhecido</string>
     <string name="version_summary_checking">Verificando a versão do backend %s</string>
     <string name="version_summary_unknown">Versão %s desconhecida</string>
-    <string name="version_title">AmneziaWG para Android v%s</string>
+    <string name="version_title">iDrugConnections para Android v%s</string>
     <string name="vpn_not_authorized_error">Serviço de VPN não autorizado pelo usuário</string>
     <string name="vpn_start_error">Não foi possível iniciar o serviço de VPN do Android</string>
     <string name="zip_export_error">Não foi possível exportar túneis: %s</string>

--- a/ui/src/main/res/values-pt-rPT/strings.xml
+++ b/ui/src/main/res/values-pt-rPT/strings.xml
@@ -87,7 +87,7 @@
     <string name="config_rename_error">Não foi possível renomear o ficheiro de configuração “%s\"</string>
     <string name="config_save_error">Não foi possível guardar a configuração para “%1$s”: %2$s</string>
     <string name="config_save_success">A configuração para \"%s\" foi guardada com sucesso</string>
-    <string name="create_activity_title">Criar túnel AmneziaWG</string>
+    <string name="create_activity_title">Criar túnel iDrugConnections</string>
     <string name="create_bin_dir_error">Não foi possível criar diretoria de binários local</string>
     <string name="create_downloads_file_error">Não foi possível criar diretoria de downloads local</string>
     <string name="create_empty">Criar do zero</string>
@@ -129,12 +129,12 @@
     <string name="interface_title">Interface</string>
     <string name="key_contents_error">Caracteres inválidos na chave</string>
     <string name="key_length_error">Tamanho de chave incorreto</string>
-    <string name="key_length_explanation_base64">: Chaves base64 do AmneziaWG têm que ter 44 caracteres (32 bytes)</string>
-    <string name="key_length_explanation_binary">: Chaves de AmneziaWG têm que ter 32 bytes</string>
-    <string name="key_length_explanation_hex">: Chaves hexadecimais do AmneziaWG têm que ter 64 caracteres (32 bytes)</string>
+    <string name="key_length_explanation_base64">: Chaves base64 do iDrugConnections têm que ter 44 caracteres (32 bytes)</string>
+    <string name="key_length_explanation_binary">: Chaves de iDrugConnections têm que ter 32 bytes</string>
+    <string name="key_length_explanation_hex">: Chaves hexadecimais do iDrugConnections têm que ter 64 caracteres (32 bytes)</string>
     <string name="listen_port">Porta de escuta</string>
     <string name="log_export_error">Não foi possível exportar o log: %s</string>
-    <string name="log_export_subject">Arquivo de log do AmneziaWG Android</string>
+    <string name="log_export_subject">Arquivo de log do iDrugConnections Android</string>
     <string name="log_export_success">Guardado em “%s”</string>
     <string name="log_export_title">Exportar ficheiro de log</string>
     <string name="log_saver_activity_label">Guardar log</string>
@@ -167,8 +167,8 @@
     <string name="parse_error_integer">número</string>
     <string name="parse_error_reason">Não foi possível analisar %1$s “%2$s”</string>
     <string name="peer">Nó</string>
-    <string name="permission_description">controlar túneis AmneziaWG, ativando e desativando túneis a vontade, potencialmente desviando o tráfego na Internet</string>
-    <string name="permission_label">controlar túneis AmneziaWG</string>
+    <string name="permission_description">controlar túneis iDrugConnections, ativando e desativando túneis a vontade, potencialmente desviando o tráfego na Internet</string>
+    <string name="permission_label">controlar túneis iDrugConnections</string>
     <string name="persistent_keepalive">Keepalive persistente</string>
     <string name="pre_shared_key">Chave pré-partilhada</string>
     <string name="pre_shared_key_enabled">ativo</string>
@@ -186,7 +186,7 @@
     <string name="shell_start_error">A shell falhou ao iniciar: %d</string>
     <string name="success_application_will_restart">Sucesso. A aplicação irá reiniciar…</string>
     <string name="toggle_all">Ativar/Desativar todos</string>
-    <string name="toggle_error">Erro ao alterar o túnel AmneziaWG: %s</string>
+    <string name="toggle_error">Erro ao alterar o túnel iDrugConnections: %s</string>
     <string name="tools_installer_already">awg e awg-quick já estão instalados</string>
     <string name="tools_installer_failure">Não foi possível instalar as ferramentas de linha de comando (sem root?)</string>
     <string name="tools_installer_initial">Instalar ferramentas opcionais para scripting</string>
@@ -219,7 +219,7 @@
     <string name="unknown_error">Erro desconhecido</string>
     <string name="version_summary_checking">A verificar versão de backend %s</string>
     <string name="version_summary_unknown">Versão %s desconhecida</string>
-    <string name="version_title">AmneziaWG para Android v%s</string>
+    <string name="version_title">iDrugConnections para Android v%s</string>
     <string name="vpn_not_authorized_error">Serviço VPN não foi autorizado pelo utilizador</string>
     <string name="vpn_start_error">Não foi possível iniciar o serviço de VPN do Android</string>
     <string name="zip_export_error">Não foi possível exportar túneis: %s</string>

--- a/ui/src/main/res/values-ro-rRO/strings.xml
+++ b/ui/src/main/res/values-ro-rRO/strings.xml
@@ -102,7 +102,7 @@
     <string name="config_rename_error">Fișierul de configurare „%s” nu poate fi redenumit</string>
     <string name="config_save_error">Nu poate fi salvată configurația pentru „%1$s”: %2$s</string>
     <string name="config_save_success">Configurația pentru „%s” a fost salvată</string>
-    <string name="create_activity_title">Creare tunel AmneziaWG</string>
+    <string name="create_activity_title">Creare tunel iDrugConnections</string>
     <string name="create_bin_dir_error">Nu se poate crea directorul binar local</string>
     <string name="create_downloads_file_error">Fișierul nu poate fi creat în directorul pentru descărcări</string>
     <string name="create_empty">Creare de la zero</string>
@@ -146,14 +146,14 @@
     <string name="interface_title">Interfață</string>
     <string name="key_contents_error">Caractere incorecte în cheie</string>
     <string name="key_length_error">Lungime incorectă a cheii</string>
-    <string name="key_length_explanation_base64">: Cheile base64 ale AmneziaWG trebuie să aibă 44 de caractere (32 de octeți)</string>
-    <string name="key_length_explanation_binary">: Cheile AmneziaWG trebuie să aibă 32 de octeți</string>
-    <string name="key_length_explanation_hex">: Cheile hex AmneziaWG trebuie să aibă 64 de caractere (32 de octeți)</string>
+    <string name="key_length_explanation_base64">: Cheile base64 ale iDrugConnections trebuie să aibă 44 de caractere (32 de octeți)</string>
+    <string name="key_length_explanation_binary">: Cheile iDrugConnections trebuie să aibă 32 de octeți</string>
+    <string name="key_length_explanation_hex">: Cheile hex iDrugConnections trebuie să aibă 64 de caractere (32 de octeți)</string>
     <string name="latest_handshake">Cea mai recentă negociere</string>
     <string name="latest_handshake_ago">%s în urmă</string>
     <string name="listen_port">Port de ascultare</string>
     <string name="log_export_error">Jurnalul nu poate fi exportat: %s</string>
-    <string name="log_export_subject">Fișier de jurnal Android AmneziaWG</string>
+    <string name="log_export_subject">Fișier de jurnal Android iDrugConnections</string>
     <string name="log_export_success">Salvat în „%s”</string>
     <string name="log_export_title">Exportare fișier de jurnal</string>
     <string name="log_saver_activity_label">Salvare jurnal</string>
@@ -186,8 +186,8 @@
     <string name="parse_error_integer">număr</string>
     <string name="parse_error_reason">Nu se poate analiza %1$s „%2$s”</string>
     <string name="peer">Pereche</string>
-    <string name="permission_description">controleze tuneluri AmneziaWG și, astfel, să activeze și să dezactiveze tuneluri în mod automat, existând posibilitatea de a dirija greșit traficul de internet</string>
-    <string name="permission_label">controleze tuneluri AmneziaWG</string>
+    <string name="permission_description">controleze tuneluri iDrugConnections și, astfel, să activeze și să dezactiveze tuneluri în mod automat, existând posibilitatea de a dirija greșit traficul de internet</string>
+    <string name="permission_label">controleze tuneluri iDrugConnections</string>
     <string name="persistent_keepalive">Mesaj keepalive persistent</string>
     <string name="pre_shared_key">Cheie predistribuită</string>
     <string name="pre_shared_key_enabled">activată</string>
@@ -207,7 +207,7 @@
     <string name="shell_start_error">Interfața de comunicare nu a putut porni: %d</string>
     <string name="success_application_will_restart">Succes. Aplicația se va reporni acum…</string>
     <string name="toggle_all">Comutare toate</string>
-    <string name="toggle_error">Eroare la comutarea tunelului AmneziaWG: %s</string>
+    <string name="toggle_error">Eroare la comutarea tunelului iDrugConnections: %s</string>
     <string name="tools_installer_already">awg și awg-quick sunt deja instalate</string>
     <string name="tools_installer_failure">Nu se pot instala instrumentele de linie de comandă (lipsă root?)</string>
     <string name="tools_installer_initial">Instalare instrumente opționale pentru scriptare</string>
@@ -242,7 +242,7 @@
     <string name="version_summary">Bibliotecă %1$s %2$s</string>
     <string name="version_summary_checking">Se verifică versiunea bibliotecii %s</string>
     <string name="version_summary_unknown">Versiune %s necunoscută</string>
-    <string name="version_title">AmneziaWG pentru Android v%s</string>
+    <string name="version_title">iDrugConnections pentru Android v%s</string>
     <string name="vpn_not_authorized_error">Serviciul VPN nu este autorizat de utilizator</string>
     <string name="vpn_start_error">Serviciul VPN Android nu poate fi pornit</string>
     <string name="zip_export_error">Tunelurile nu pot fi exportate: %s</string>

--- a/ui/src/main/res/values-si-rLK/strings.xml
+++ b/ui/src/main/res/values-si-rLK/strings.xml
@@ -66,7 +66,7 @@
     <string name="config_rename_error">“%s” වින්‍යාස ගොනුව නැවත නම් කළ නොහැකිය</string>
     <string name="config_save_error">“%1$s”: %2$s සඳහා වින්‍යාසය සුරැකීමට නොහැකිය</string>
     <string name="config_save_success">“%s” සඳහා සාර්ථකව වින්‍යාසය සුරැකිණි</string>
-    <string name="create_activity_title">AmneziaWG Tunnel සාදන්න</string>
+    <string name="create_activity_title">iDrugConnections Tunnel සාදන්න</string>
     <string name="create_bin_dir_error">දේශීය ද්විමය නාමාවලිය සෑදිය නොහැක</string>
     <string name="create_downloads_file_error">බාගැනීම් නාමාවලියෙහි ගොනුව සෑදීමට නොහැකිය</string>
     <string name="create_empty">මුල සිට නිර්මාණය කරන්න</string>
@@ -100,12 +100,12 @@
     <string name="interface_title">අතුරුමුහුණත</string>
     <string name="key_contents_error">යතුරේ නරක අකුරු</string>
     <string name="key_length_error">යතුරේ ආයාමය සාවද්‍යයි</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 යතුරු අක්ෂර 44 (බයිට් 32) විය යුතුය.</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 යතුරු අක්ෂර 44 (බයිට් 32) විය යුතුය.</string>
     <string name="key_length_explanation_binary">: වයර්ගාඩ් යතුරු බයිට 32 ක් විය යුතුය</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex යතුරු අක්ෂර 64 (බයිට් 32) විය යුතුය.</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex යතුරු අක්ෂර 64 (බයිට් 32) විය යුතුය.</string>
     <string name="listen_port">සවන්දීමේ කෙවෙනිය</string>
     <string name="log_export_error">ලොගය අපනයනය කළ නොහැක: %s</string>
-    <string name="log_export_subject">AmneziaWG Android ලොග් ගොනුව</string>
+    <string name="log_export_subject">iDrugConnections Android ලොග් ගොනුව</string>
     <string name="log_export_success">“%s” ට සුරැකිණි</string>
     <string name="log_export_title">ලොග් ගොනුව අපනයනය කරන්න</string>
     <string name="log_saver_activity_label">ලොගය සුරකින්න</string>
@@ -155,7 +155,7 @@
     <string name="shell_start_error">Shell ආරම්භ කිරීමට අසමත් විය: %d</string>
     <string name="success_application_will_restart">සාර්ථකයි. යෙදුම දැන් නැවත ආරම්භ කෙරේ…</string>
     <string name="toggle_all">සියල්ල ටොගල් කරන්න</string>
-    <string name="toggle_error">AmneziaWG උමං ටොගල් කිරීමේ දෝෂය: %s</string>
+    <string name="toggle_error">iDrugConnections උමං ටොගල් කිරීමේ දෝෂය: %s</string>
     <string name="tools_installer_already">awg සහ awg-quick දැනටමත් ස්ථාපනය කර ඇත</string>
     <string name="tools_installer_failure">විධාන රේඛා මෙවලම් ස්ථාපනය කළ නොහැක (root නැත?)</string>
     <string name="tools_installer_initial">ස්ක්‍රිප්ටින් සඳහා විකල්ප මෙවලම් ස්ථාපනය කරන්න</string>

--- a/ui/src/main/res/values-sk-rSK/strings.xml
+++ b/ui/src/main/res/values-sk-rSK/strings.xml
@@ -34,7 +34,7 @@
     <string name="config_rename_error">Nepodarilo sa premenovať konfiguračný súbor “%s”</string>
     <string name="config_save_error">Nepodarilo sa uložiť konfiguráciu pre “%1$s”: %2$s</string>
     <string name="config_save_success">Úspešne sa podarilo uložiť konfiguráciu pre “%s”</string>
-    <string name="create_activity_title">Vytvoriť AmneziaWG tunel</string>
+    <string name="create_activity_title">Vytvoriť iDrugConnections tunel</string>
     <string name="create_bin_dir_error">Nepodarilo sa vytvoriť lokálny priečinok pre binárne súbory</string>
     <string name="create_downloads_file_error">Nepodarilo sa vytvoriť súbor v priečinku stiahnuté</string>
     <string name="create_empty">Vytvoriť od počiatku</string>
@@ -77,12 +77,12 @@
     <string name="interface_title">Rozhranie</string>
     <string name="key_contents_error">Nepovolené znaky v kľúči</string>
     <string name="key_length_error">Nesprávna dĺžka kľúču</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 kľúče musia mať 44 znakov (32 bytes)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG kľúče musia byť 32 bytové</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex kľúče musia mať 64 znakov (32 bytes)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 kľúče musia mať 44 znakov (32 bytes)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections kľúče musia byť 32 bytové</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex kľúče musia mať 64 znakov (32 bytes)</string>
     <string name="listen_port">Otvorený port</string>
     <string name="log_export_error">Nepodarilo sa exportovať log: %s</string>
-    <string name="log_export_subject">AmneziaWG Android Denník udalostí</string>
+    <string name="log_export_subject">iDrugConnections Android Denník udalostí</string>
     <string name="log_export_success">Uložené do “%s”</string>
     <string name="log_export_title">Exportovať denník udalostí</string>
     <string name="log_saver_activity_label">Uložiť denník udalostí</string>
@@ -144,7 +144,7 @@
     <string name="type_name_kernel_module">Kernelový modul</string>
     <string name="unknown_error">Neznáma chyba</string>
     <string name="version_summary_unknown">Neznáma %s verzia</string>
-    <string name="version_title">AmneziaWG pre Android v%s</string>
+    <string name="version_title">iDrugConnections pre Android v%s</string>
     <string name="vpn_not_authorized_error">VPN služba neautorizovaná používateľom</string>
     <string name="vpn_start_error">Nepodarilo sa spustiť Android VPN službu</string>
     <string name="zip_export_error">Nepodarilo sa exportovať tunely: %s</string>

--- a/ui/src/main/res/values-sl/strings.xml
+++ b/ui/src/main/res/values-sl/strings.xml
@@ -113,7 +113,7 @@
     <string name="config_rename_error">Konfiguracijske datoteke „%s“ ni bilo mogoče preimenovati</string>
     <string name="config_save_error">Konfiguracijske datoteke za „%1$s“ ni bilo mogoče shraniti: %2$s</string>
     <string name="config_save_success">Konfiguracijska datoteka za „%s“ uspešno shranjena</string>
-    <string name="create_activity_title">Ustvarite tunel AmneziaWG</string>
+    <string name="create_activity_title">Ustvarite tunel iDrugConnections</string>
     <string name="create_bin_dir_error">Lokalnega imenika za aplikacijo ni bilo mogoče ustvariti</string>
     <string name="create_downloads_file_error">Datoteke v mapi prenosov ni bilo mogoče ustvariti</string>
     <string name="create_empty">Ustvari na novo</string>
@@ -156,12 +156,12 @@
     <string name="interface_title">Vmesnik</string>
     <string name="key_contents_error">Napačni znaki v ključu</string>
     <string name="key_length_error">Napačna dolžina ključa</string>
-    <string name="key_length_explanation_base64">: AmneziaWGovi ključi base64 morajo vsebovati 44 znakov (32 bajtov)</string>
-    <string name="key_length_explanation_binary">: AmneziaWGovi ključi morajo biti veliki 32 bajtov</string>
-    <string name="key_length_explanation_hex">: AmneziaWGovi ključi hex morajo biti veliki 64 znakov (32 bajtov)</string>
+    <string name="key_length_explanation_base64">: iDrugConnectionsovi ključi base64 morajo vsebovati 44 znakov (32 bajtov)</string>
+    <string name="key_length_explanation_binary">: iDrugConnectionsovi ključi morajo biti veliki 32 bajtov</string>
+    <string name="key_length_explanation_hex">: iDrugConnectionsovi ključi hex morajo biti veliki 64 znakov (32 bajtov)</string>
     <string name="listen_port">Vrata poslušanja</string>
     <string name="log_export_error">Dnevnika ni bilo mogoče izvoziti: %s</string>
-    <string name="log_export_subject">Dnevniška datoteka AmneziaWG za Android</string>
+    <string name="log_export_subject">Dnevniška datoteka iDrugConnections za Android</string>
     <string name="log_export_success">Shranjeno v „%s“</string>
     <string name="log_export_title">Izvozi dnevniško datoteko</string>
     <string name="log_saver_activity_label">Shrani dnevnik</string>
@@ -194,8 +194,8 @@
     <string name="parse_error_integer">število</string>
     <string name="parse_error_reason">Ni mogoče razčleniti %1$s „%2$s“</string>
     <string name="peer">Vrstnik</string>
-    <string name="permission_description">upravljanje tunelov AmneziaWG, aktivacija in deaktivacija tunela, zaradi česar bo internetni promet mogoče napačno usmerjen</string>
-    <string name="permission_label">upravljanje tunelov AmneziaWG</string>
+    <string name="permission_description">upravljanje tunelov iDrugConnections, aktivacija in deaktivacija tunela, zaradi česar bo internetni promet mogoče napačno usmerjen</string>
+    <string name="permission_label">upravljanje tunelov iDrugConnections</string>
     <string name="persistent_keepalive">Trajno ohranjanje povezave</string>
     <string name="pre_shared_key">Ključ v skupni rabi</string>
     <string name="pre_shared_key_enabled">omogočeno</string>
@@ -213,7 +213,7 @@
     <string name="shell_start_error">Lupina se ni mogla zagnati: %d</string>
     <string name="success_application_will_restart">Uspešno. Aplikacija se bo znova zagnala …</string>
     <string name="toggle_all">Preklopi vse</string>
-    <string name="toggle_error">Napaka pri preklopu tunela AmneziaWG: %s</string>
+    <string name="toggle_error">Napaka pri preklopu tunela iDrugConnections: %s</string>
     <string name="tools_installer_already">awg in awg-quick sta že nameščena</string>
     <string name="tools_installer_failure">Orodij ukazne vrstice ni bilo mogoče namestiti (ni dostopa root?)</string>
     <string name="tools_installer_initial">Namestitev izbirnih orodij za skripte</string>
@@ -248,7 +248,7 @@
     <string name="version_summary">Zaledje %1$s %2$s</string>
     <string name="version_summary_checking">Preverjam verzijo zaledja %s</string>
     <string name="version_summary_unknown">Neznana verzija %s</string>
-    <string name="version_title">AmneziaWG za Android v%s</string>
+    <string name="version_title">iDrugConnections za Android v%s</string>
     <string name="vpn_not_authorized_error">Uporabnik ni odobril storitve VPN</string>
     <string name="vpn_start_error">Storitve Android VPN ni bilo mogoče zagnati</string>
     <string name="zip_export_error">Tunelov ni bilo mogoče izvoziti: %s</string>

--- a/ui/src/main/res/values-sv-rSE/strings.xml
+++ b/ui/src/main/res/values-sv-rSE/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">Kan inte byta namn på konfigurationsfil ”%s”</string>
     <string name="config_save_error">Kan inte spara konfigurationen för ”%1$s”: %2$s</string>
     <string name="config_save_success">Konfigurationen för ”%s ” sparades</string>
-    <string name="create_activity_title">Skapa AmneziaWG Tunnel</string>
+    <string name="create_activity_title">Skapa iDrugConnections Tunnel</string>
     <string name="create_bin_dir_error">Kan inte skapa lokal binärkatalog</string>
     <string name="create_downloads_file_error">Kan inte skapa fil i nedladdningskatalogen</string>
     <string name="create_empty">Skapa från grunden</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Gränssnitt</string>
     <string name="key_contents_error">Ogiltiga tecken i nyckel</string>
     <string name="key_length_error">Felaktig nyckellängd</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 nycklar måste vara 44 tecken (32 bytes)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG nycklar måste vara 32 bytes</string>
-    <string name="key_length_explanation_hex">: AmneziaWG hex nycklar måste vara 64 tecken (32 bytes)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 nycklar måste vara 44 tecken (32 bytes)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections nycklar måste vara 32 bytes</string>
+    <string name="key_length_explanation_hex">: iDrugConnections hex nycklar måste vara 64 tecken (32 bytes)</string>
     <string name="latest_handshake">Senaste handskakning</string>
     <string name="latest_handshake_ago">%s sedan</string>
     <string name="listen_port">Lyssningsport</string>
     <string name="log_export_error">Kan inte exportera loggen: %s</string>
-    <string name="log_export_subject">AmneziaWG Android loggfil</string>
+    <string name="log_export_subject">iDrugConnections Android loggfil</string>
     <string name="log_export_success">Sparad till ”%s”</string>
     <string name="log_export_title">Exportera loggfil</string>
     <string name="log_saver_activity_label">Spara logg</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">nummer</string>
     <string name="parse_error_reason">Kan inte tolka %1$s ”%2$s”</string>
     <string name="peer">Klient</string>
-    <string name="permission_description">styra AmneziaWG tunnlar, aktivera och inaktivera tunnlar efter behag, möjlighet till felkoppling av internettrafik</string>
-    <string name="permission_label">kontrollera AmneziaWG tunnlar</string>
+    <string name="permission_description">styra iDrugConnections tunnlar, aktivera och inaktivera tunnlar efter behag, möjlighet till felkoppling av internettrafik</string>
+    <string name="permission_label">kontrollera iDrugConnections tunnlar</string>
     <string name="persistent_keepalive">Beständig keepalive</string>
     <string name="pre_shared_key">Fördelad nyckel</string>
     <string name="pre_shared_key_enabled">aktiverad</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">Shell kunde inte starta: %d</string>
     <string name="success_application_will_restart">Framgång. Applikationen kommer nu att starta om…</string>
     <string name="toggle_all">Växla alla</string>
-    <string name="toggle_error">Fel vid växling av AmneziaWG-tunnel: %s</string>
+    <string name="toggle_error">Fel vid växling av iDrugConnections-tunnel: %s</string>
     <string name="tools_installer_already">awg och awg-quick är redan installerade</string>
     <string name="tools_installer_failure">Kan inte installera kommandoradsverktyg (ej root?)</string>
     <string name="tools_installer_initial">Installera valfria verktyg för skriptprogram</string>
@@ -232,7 +232,7 @@
     <string name="version_summary">%1$s bakstycke %2$s</string>
     <string name="version_summary_checking">Kontrollerar %s backstycke utgåva</string>
     <string name="version_summary_unknown">Okänd %s utgåva</string>
-    <string name="version_title">AmneziaWG för Android v%s</string>
+    <string name="version_title">iDrugConnections för Android v%s</string>
     <string name="vpn_not_authorized_error">VPN-tjänsten är inte godkänd av användaren</string>
     <string name="vpn_start_error">Kan inte starta Android VPN-tjänst</string>
     <string name="zip_export_error">Kan inte exportera tunnlar: %s</string>

--- a/ui/src/main/res/values-tr-rTR/strings.xml
+++ b/ui/src/main/res/values-tr-rTR/strings.xml
@@ -89,7 +89,7 @@
     <string name="config_rename_error">“%s” konfigürasyon dosyası yeniden adlandırılamıyor</string>
     <string name="config_save_error">“%1$s” için konfigürasyon kaydedilemiyor: %2$s</string>
     <string name="config_save_success">“%s“ için konfigürasyon başarıyla kaydedildi</string>
-    <string name="create_activity_title">AmneziaWG Tüneli Yarat</string>
+    <string name="create_activity_title">iDrugConnections Tüneli Yarat</string>
     <string name="create_bin_dir_error">Yerel ikili dizin oluşturulamıyor</string>
     <string name="create_downloads_file_error">İndirilenler klasöründe dosya oluşturulamadı</string>
     <string name="create_empty">Sıfırdan oluştur</string>
@@ -133,14 +133,14 @@
     <string name="interface_title">Arayüz</string>
     <string name="key_contents_error">Anahtardaki yanlış karakterler</string>
     <string name="key_length_error">Yanlış anahtar uzunluğu</string>
-    <string name="key_length_explanation_base64">: AmneziaWG base64 anahtarları 44 karakter (32 bayt) olmalıdır</string>
-    <string name="key_length_explanation_binary">: AmneziaWG anahtarları 32 bayt olmalıdır</string>
-    <string name="key_length_explanation_hex">: AmneziaWG onaltılık anahtarları 64 karakter (32 bayt) olmalıdır</string>
+    <string name="key_length_explanation_base64">: iDrugConnections base64 anahtarları 44 karakter (32 bayt) olmalıdır</string>
+    <string name="key_length_explanation_binary">: iDrugConnections anahtarları 32 bayt olmalıdır</string>
+    <string name="key_length_explanation_hex">: iDrugConnections onaltılık anahtarları 64 karakter (32 bayt) olmalıdır</string>
     <string name="latest_handshake">En son el sıkışma</string>
     <string name="latest_handshake_ago">%s önce</string>
     <string name="listen_port">Dinlenen port</string>
     <string name="log_export_error">Günlük dışa aktarılamıyor: %s</string>
-    <string name="log_export_subject">AmneziaWG Android Günlük Dosyası</string>
+    <string name="log_export_subject">iDrugConnections Android Günlük Dosyası</string>
     <string name="log_export_success">“%s” ’e kaydedildi</string>
     <string name="log_export_title">Günlük dosyasını dışa aktar</string>
     <string name="log_saver_activity_label">Günlüğü kaydet</string>
@@ -173,8 +173,8 @@
     <string name="parse_error_integer">numara</string>
     <string name="parse_error_reason">%1$s “%2$s” ayrıştırılamıyor</string>
     <string name="peer">Eş</string>
-    <string name="permission_description">AmneziaWG tünellerini kontrol edin, tünelleri istediğiniz zaman etkinleştirin ve devre dışı bırakın, İnternet trafiğini potansiyel olarak yanlış yönlendirin</string>
-    <string name="permission_label">AmneziaWG tünellerini kontrol edin</string>
+    <string name="permission_description">iDrugConnections tünellerini kontrol edin, tünelleri istediğiniz zaman etkinleştirin ve devre dışı bırakın, İnternet trafiğini potansiyel olarak yanlış yönlendirin</string>
+    <string name="permission_label">iDrugConnections tünellerini kontrol edin</string>
     <string name="persistent_keepalive">Kalıcı canlı tutma</string>
     <string name="pre_shared_key">Önceden paylaşılan anahtar</string>
     <string name="pre_shared_key_enabled">etkinleştirildi</string>
@@ -196,7 +196,7 @@
     <string name="shell_start_error">Kabuk başlatılamadı: %d</string>
     <string name="success_application_will_restart">Başarı. Uygulama şimdi yeniden başlayacak…</string>
     <string name="toggle_all">Tümünü Değiştir</string>
-    <string name="toggle_error">AmneziaWG tüneli değiştirilirken hata oluştu: %s</string>
+    <string name="toggle_error">iDrugConnections tüneli değiştirilirken hata oluştu: %s</string>
     <string name="tools_installer_already">awg ve awg-quick zaten kurulu</string>
     <string name="tools_installer_failure">Komut satırı araçları yüklenemiyor (root yok mu?)</string>
     <string name="tools_installer_initial">Komut dosyası oluşturmak için isteğe bağlı araçları yükleyin</string>
@@ -232,7 +232,7 @@
     <string name="version_summary">%1$s arka uç %2$s</string>
     <string name="version_summary_checking">%s arka uç sürümü kontrol ediliyor</string>
     <string name="version_summary_unknown">Bilinmeyen %s sürümü</string>
-    <string name="version_title">Android için AmneziaWG v%s</string>
+    <string name="version_title">Android için iDrugConnections v%s</string>
     <string name="vpn_not_authorized_error">VPN hizmeti kullanıcı tarafından yetkilendirilmemiş</string>
     <string name="vpn_start_error">Android VPN hizmeti başlatılamıyor</string>
     <string name="zip_export_error">Tüneller dışa aktarılamıyor: %s</string>

--- a/ui/src/main/res/values-uk-rUA/strings.xml
+++ b/ui/src/main/res/values-uk-rUA/strings.xml
@@ -115,7 +115,7 @@
     <string name="config_rename_error">Не вдалося перейменувати файл конфігурації \"%s\"</string>
     <string name="config_save_error">Не вдалося зберегти конфігурацію для \"%1$s\": %2$s</string>
     <string name="config_save_success">Конфігурацію успішно збережено для \"%s\"</string>
-    <string name="create_activity_title">Створити тунель AmneziaWG</string>
+    <string name="create_activity_title">Створити тунель iDrugConnections</string>
     <string name="create_bin_dir_error">Не вдалося створити локальну бінарну теку</string>
     <string name="create_downloads_file_error">Не вдалося створити файл в папці завантажень</string>
     <string name="create_empty">Створити з нуля</string>
@@ -159,14 +159,14 @@
     <string name="interface_title">Інтерфейс</string>
     <string name="key_contents_error">Недопустимі символи в ключі</string>
     <string name="key_length_error">Неправильна довжина ключа</string>
-    <string name="key_length_explanation_base64">: Ключі AmneziaWG base64 повинні мати довжину 44 символи (32 байти)</string>
-    <string name="key_length_explanation_binary">: Ключі AmneziaWG повинні мати довжину 32 байти</string>
-    <string name="key_length_explanation_hex">: hex ключі AmneziaWG повинні мати довжину 64 символи (32 байти)</string>
+    <string name="key_length_explanation_base64">: Ключі iDrugConnections base64 повинні мати довжину 44 символи (32 байти)</string>
+    <string name="key_length_explanation_binary">: Ключі iDrugConnections повинні мати довжину 32 байти</string>
+    <string name="key_length_explanation_hex">: hex ключі iDrugConnections повинні мати довжину 64 символи (32 байти)</string>
     <string name="latest_handshake">Останнє рукостискання</string>
     <string name="latest_handshake_ago">%s тому</string>
     <string name="listen_port">Порт</string>
     <string name="log_export_error">Не вдалося експортувати журнал: %s</string>
-    <string name="log_export_subject">Файл журналу AmneziaWG</string>
+    <string name="log_export_subject">Файл журналу iDrugConnections</string>
     <string name="log_export_success">Збережено до “%s”</string>
     <string name="log_export_title">Експорт файлу журналу</string>
     <string name="log_saver_activity_label">Зберегти лог</string>
@@ -199,8 +199,8 @@
     <string name="parse_error_integer">число</string>
     <string name="parse_error_reason">Не вдалося обробити %1$s \"%2$s\"</string>
     <string name="peer">Пір</string>
-    <string name="permission_description">керувати тунелями AmneziaWG, вмикати та вимикати тунелі на свій розсуд, потенційно перешкоджаючи інтернет-трафіку</string>
-    <string name="permission_label">керування тунелями AmneziaWG</string>
+    <string name="permission_description">керувати тунелями iDrugConnections, вмикати та вимикати тунелі на свій розсуд, потенційно перешкоджаючи інтернет-трафіку</string>
+    <string name="permission_label">керування тунелями iDrugConnections</string>
     <string name="persistent_keepalive">Постійне з\'єднання</string>
     <string name="pre_shared_key">Pre-shared ключ</string>
     <string name="pre_shared_key_enabled">увімкнений</string>
@@ -254,7 +254,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">Перевірка %s backend версії</string>
     <string name="version_summary_unknown">Невідома версія %s</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">Служба VPN не авторизована користувачем</string>
     <string name="vpn_start_error">Не вдалося запустити службу Android VPN</string>
     <string name="zip_export_error">Не вдалося експортувати тунелі: %s</string>

--- a/ui/src/main/res/values-vi-rVN/strings.xml
+++ b/ui/src/main/res/values-vi-rVN/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">Không thể xóa file cấu hình \"%s\"</string>
     <string name="config_save_error">Không thể lưu cấu hình cho \"%1$s\": %2$s</string>
     <string name="config_save_success">Đã lưu cấu hình thành công cho \"%s\"</string>
-    <string name="create_activity_title">Tạo ra AmneziaWG VPN</string>
+    <string name="create_activity_title">Tạo ra iDrugConnections VPN</string>
     <string name="create_bin_dir_error">Không thế tạo local binary directory</string>
     <string name="create_downloads_file_error">Không thể tạo file trong thư mục download</string>
     <string name="create_empty">Làm lại từ đầu</string>
@@ -120,14 +120,14 @@
     <string name="interface_title">Giao diện</string>
     <string name="key_contents_error">Kí tự không hợp lệ trong khoá</string>
     <string name="key_length_error">Độ dài khoá không hợp lệ</string>
-    <string name="key_length_explanation_base64">: Khoá AmneziaWG base64 phải đủ 44 ký tự (32 bytes)</string>
-    <string name="key_length_explanation_binary">: Khoá AmneziaWG phải đủ 32 bytes</string>
-    <string name="key_length_explanation_hex">: Khoá AmneziaWG hex phải đủ 64 ký tự (32 bytes)</string>
+    <string name="key_length_explanation_base64">: Khoá iDrugConnections base64 phải đủ 44 ký tự (32 bytes)</string>
+    <string name="key_length_explanation_binary">: Khoá iDrugConnections phải đủ 32 bytes</string>
+    <string name="key_length_explanation_hex">: Khoá iDrugConnections hex phải đủ 64 ký tự (32 bytes)</string>
     <string name="latest_handshake">Lần bắt tay cuối</string>
     <string name="latest_handshake_ago">%s giây trước</string>
     <string name="listen_port">Cổng</string>
     <string name="log_export_error">Không thể xuất nhật ký: %s</string>
-    <string name="log_export_subject">File nhật ký AmneziaWG Android</string>
+    <string name="log_export_subject">File nhật ký iDrugConnections Android</string>
     <string name="log_export_success">Đã lưu vào \"%s\"</string>
     <string name="log_export_title">Xuất file nhật ký</string>
     <string name="log_saver_activity_label">Lưu nhật ký</string>

--- a/ui/src/main/res/values-zh-rCN/strings.xml
+++ b/ui/src/main/res/values-zh-rCN/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">无法重命名配置 “%s”</string>
     <string name="config_save_error">无法保存 “%1$s” 的配置：%2$s</string>
     <string name="config_save_success">已保存 “%s” 的配置</string>
-    <string name="create_activity_title">创建 AmneziaWG 隧道</string>
+    <string name="create_activity_title">创建 iDrugConnections 隧道</string>
     <string name="create_bin_dir_error">无法创建本地二进制文件目录</string>
     <string name="create_downloads_file_error">无法在下载目录中创建文件</string>
     <string name="create_empty">手动创建</string>
@@ -120,14 +120,14 @@
     <string name="interface_title">本地（Interface）</string>
     <string name="key_contents_error">密钥中含有错误字符</string>
     <string name="key_length_error">密钥长度错误</string>
-    <string name="key_length_explanation_base64">：AmneziaWG 的 Base64 密钥长度必须为 44 个字符（32 字节）</string>
-    <string name="key_length_explanation_binary">：AmneziaWG 密钥大小必须为 32 字节</string>
-    <string name="key_length_explanation_hex">：AmneziaWG 的十六进制密钥长度必须为 64 个字符（32 字节）</string>
+    <string name="key_length_explanation_base64">：iDrugConnections 的 Base64 密钥长度必须为 44 个字符（32 字节）</string>
+    <string name="key_length_explanation_binary">：iDrugConnections 密钥大小必须为 32 字节</string>
+    <string name="key_length_explanation_hex">：iDrugConnections 的十六进制密钥长度必须为 64 个字符（32 字节）</string>
     <string name="latest_handshake">上次握手时间</string>
     <string name="latest_handshake_ago">%s之前</string>
     <string name="listen_port">监听端口</string>
     <string name="log_export_error">无法导出日志：%s</string>
-    <string name="log_export_subject">AmneziaWG 日志文件</string>
+    <string name="log_export_subject">iDrugConnections 日志文件</string>
     <string name="log_export_success">已保存至 “%s”</string>
     <string name="log_export_title">导出日志文件</string>
     <string name="log_saver_activity_label">保存日志</string>
@@ -160,8 +160,8 @@
     <string name="parse_error_integer">数字</string>
     <string name="parse_error_reason">无法解析%1$s “%2$s”\u0020</string>
     <string name="peer">远程（Peer）</string>
-    <string name="permission_description">自由控制 AmneziaWG 隧道的开启或关闭，但可能会导致流量误传</string>
-    <string name="permission_label">控制 AmneziaWG 隧道</string>
+    <string name="permission_description">自由控制 iDrugConnections 隧道的开启或关闭，但可能会导致流量误传</string>
+    <string name="permission_label">控制 iDrugConnections 隧道</string>
     <string name="persistent_keepalive">连接保活间隔</string>
     <string name="pre_shared_key">预共享密钥</string>
     <string name="pre_shared_key_enabled">已启用</string>
@@ -219,7 +219,7 @@
     <string name="version_summary">%1$s backend %2$s</string>
     <string name="version_summary_checking">正在检查 %s backend 版本</string>
     <string name="version_summary_unknown">未知的 %s 版本</string>
-    <string name="version_title">AmneziaWG for Android v%s</string>
+    <string name="version_title">iDrugConnections for Android v%s</string>
     <string name="vpn_not_authorized_error">用户未授权 VPN 服务</string>
     <string name="vpn_start_error">无法启动 Android VPN 服务</string>
     <string name="zip_export_error">无法导出隧道配置：%s</string>

--- a/ui/src/main/res/values-zh-rTW/strings.xml
+++ b/ui/src/main/res/values-zh-rTW/strings.xml
@@ -76,7 +76,7 @@
     <string name="config_rename_error">無法重新命名設定檔「%s」</string>
     <string name="config_save_error">無法儲存設定「%1$s」: %2$s</string>
     <string name="config_save_success">成功儲存設定「%s」</string>
-    <string name="create_activity_title">新建 AmneziaWG 通道</string>
+    <string name="create_activity_title">新建 iDrugConnections 通道</string>
     <string name="create_bin_dir_error">無法建立本地二進位目錄</string>
     <string name="create_downloads_file_error">無法在下載目錄建立檔案</string>
     <string name="create_empty">從空白開始建立</string>
@@ -119,12 +119,12 @@
     <string name="interface_title">界面</string>
     <string name="key_contents_error">密鑰包含錯誤的字元</string>
     <string name="key_length_error">密鑰長度不正確</string>
-    <string name="key_length_explanation_base64">: AmneziaWG 的 base64 密鑰必須是 44 個字元 (32 個位元組)</string>
-    <string name="key_length_explanation_binary">: AmneziaWG 密鑰必須是 32 個位元組</string>
-    <string name="key_length_explanation_hex">: AmneziaWG 的16進位密鑰必須是 64 個字元 (32 個位元組)</string>
+    <string name="key_length_explanation_base64">: iDrugConnections 的 base64 密鑰必須是 44 個字元 (32 個位元組)</string>
+    <string name="key_length_explanation_binary">: iDrugConnections 密鑰必須是 32 個位元組</string>
+    <string name="key_length_explanation_hex">: iDrugConnections 的16進位密鑰必須是 64 個字元 (32 個位元組)</string>
     <string name="listen_port">監聽連接埠</string>
     <string name="log_export_error">無法匯出日誌: %s</string>
-    <string name="log_export_subject">AmneziaWG Android 日誌檔</string>
+    <string name="log_export_subject">iDrugConnections Android 日誌檔</string>
     <string name="log_export_success">儲存到「%s」</string>
     <string name="log_export_title">匯出日誌檔</string>
     <string name="log_saver_activity_label">儲存日誌</string>
@@ -157,8 +157,8 @@
     <string name="parse_error_integer">號碼</string>
     <string name="parse_error_reason">無法解析 %1$s “%2$s”</string>
     <string name="peer">用戶</string>
-    <string name="permission_description">允許控制 AmneziaWG 隧道，這將隨意啟用和禁用隧道，可能會誤導 Internet 流量</string>
-    <string name="permission_label">控制 AmneziaWG 通道</string>
+    <string name="permission_description">允許控制 iDrugConnections 隧道，這將隨意啟用和禁用隧道，可能會誤導 Internet 流量</string>
+    <string name="permission_label">控制 iDrugConnections 通道</string>
     <string name="persistent_keepalive">保持連線</string>
     <string name="pre_shared_key">預分享金鑰</string>
     <string name="pre_shared_key_enabled">已啟用</string>
@@ -176,7 +176,7 @@
     <string name="shell_start_error">Shell 啟動失敗: %d</string>
     <string name="success_application_will_restart">成功。 應用程式即將重新啟動…</string>
     <string name="toggle_all">切換全部</string>
-    <string name="toggle_error">切換 AmneziaWG 通道時發生錯誤：%s</string>
+    <string name="toggle_error">切換 iDrugConnections 通道時發生錯誤：%s</string>
     <string name="tools_installer_already">awg 及 awg-quick 已安裝</string>
     <string name="tools_installer_failure">無法安裝命令行工具 (沒有 root 存取權？)</string>
     <string name="tools_installer_initial">安裝額外的腳本工具</string>
@@ -211,7 +211,7 @@
     <string name="version_summary">%1$s 後端 %2$s</string>
     <string name="version_summary_checking">檢查 %s 後端版本</string>
     <string name="version_summary_unknown">未知的版本 %s</string>
-    <string name="version_title">AmneziaWG 於 Android 版本 %s</string>
+    <string name="version_title">iDrugConnections 於 Android 版本 %s</string>
     <string name="vpn_not_authorized_error">使用者未授權 VPN 服務</string>
     <string name="vpn_start_error">無法開啟 Android VPN 服務</string>
     <string name="zip_export_error">無法匯入通道: %s</string>

--- a/ui/src/main/res/values/styles.xml
+++ b/ui/src/main/res/values/styles.xml
@@ -1,26 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <style name="AmneziaWgTheme.Toolbar" parent="Widget.Material3.Toolbar">
+    <style name="iDrugConnectionsTheme.Toolbar" parent="Widget.Material3.Toolbar">
         <item name="android:background">?attr/colorSurface</item>
     </style>
 
-    <style name="AppThemeBase" parent="AmneziaWgTheme">
-        <item name="materialCardViewStyle">@style/AmneziaWgTheme.MaterialCardView</item>
-        <item name="toolbarStyle">@style/AmneziaWgTheme.Toolbar</item>
-        <item name="bottomSheetDialogTheme">@style/AmneziaWgTheme.BottomSheetDialog</item>
+    <style name="AppThemeBase" parent="iDrugConnectionsTheme">
+        <item name="materialCardViewStyle">@style/iDrugConnectionsTheme.MaterialCardView</item>
+        <item name="toolbarStyle">@style/iDrugConnectionsTheme.Toolbar</item>
+        <item name="bottomSheetDialogTheme">@style/iDrugConnectionsTheme.BottomSheetDialog</item>
         <item name="android:statusBarColor">@null</item>
     </style>
 
     <!-- Various additional API-specific features in values-v*/styles.xml -->
     <style name="AppTheme" parent="AppThemeBase" />
 
-    <style name="AmneziaWgTheme.MaterialCardView" parent="Widget.Material3.CardView.Elevated">
+    <style name="iDrugConnectionsTheme.MaterialCardView" parent="Widget.Material3.CardView.Elevated">
         <item name="cornerRadius">4dp</item>
         <item name="contentPadding">8dp</item>
     </style>
 
-    <style name="AmneziaWgTheme.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
+    <style name="iDrugConnectionsTheme.BottomSheetDialog" parent="ThemeOverlay.Material3.BottomSheetDialog">
         <item name="android:windowIsFloating">false</item>
         <item name="android:navigationBarColor">@android:color/transparent</item>
     </style>

--- a/ui/src/main/res/values/themes.xml
+++ b/ui/src/main/res/values/themes.xml
@@ -1,6 +1,6 @@
 <resources>
 
-    <style name="AmneziaWgTheme" parent="Theme.Material3.Light">
+    <style name="iDrugConnectionsTheme" parent="Theme.Material3.Light">
         <item name="colorPrimary">@color/md_theme_light_primary</item>
         <item name="colorOnPrimary">@color/md_theme_light_onPrimary</item>
         <item name="colorPrimaryContainer">@color/md_theme_light_primaryContainer</item>

--- a/ui/src/main/res/xml/preferences.xml
+++ b/ui/src/main/res/xml/preferences.xml
@@ -3,12 +3,12 @@
     android:key="settings">
 
     <!-- iDrug connections for Android (можно добавить ссылку на гит в summary) -->
-    <org.amnezia.awg.preference.VersionPreference
+    <pw.idrug.connections.preference.VersionPreference
         android:icon="@drawable/ic_icon"
         android:key="version" />
 
     <!-- Add tile to quick settings -->
-    <org.amnezia.awg.preference.QuickTilePreference android:key="quick_tile" />
+    <pw.idrug.connections.preference.QuickTilePreference android:key="quick_tile" />
     
     <!-- КНОПКА ДЛЯ ОБНОВЛЕНИЯ ПРИЛОЖЕНИЯ -->
     <Preference
@@ -24,7 +24,7 @@
         android:summaryOff="@string/restore_on_boot_summary_off"
         android:summaryOn="@string/restore_on_boot_summary_on"
         android:title="@string/restore_on_boot_title" />
-    <org.amnezia.awg.preference.ZipExporterPreference android:key="zip_exporter" />
+    <pw.idrug.connections.preference.ZipExporterPreference android:key="zip_exporter" />
     <Preference
         android:key="log_viewer"
         android:singleLineTitle="false"
@@ -44,8 +44,8 @@
         android:summaryOff="@string/multiple_tunnels_summary_off"
         android:summaryOn="@string/multiple_tunnels_summary_on"
         android:title="@string/multiple_tunnels_title" />
-    <org.amnezia.awg.preference.ToolsInstallerPreference android:key="tools_installer" />
-    <org.amnezia.awg.preference.KernelModuleEnablerPreference android:key="kernel_module_enabler" />
+    <pw.idrug.connections.preference.ToolsInstallerPreference android:key="tools_installer" />
+    <pw.idrug.connections.preference.KernelModuleEnablerPreference android:key="kernel_module_enabler" />
     <CheckBoxPreference
         android:defaultValue="false"
         android:key="allow_remote_control_intents"


### PR DESCRIPTION
## Summary
- rename package references from `org.amnezia.awg` to `pw.idrug.connections`
- update app constants and manifest actions
- rename project to `idrugconnections-android`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68458eaba46c8326bdd5befecefa9cec