### PR TITLE
Filter app list to show only launcher apps

### DIFF
--- a/ui/src/main/java/org/amnezia/awg/fragment/AppListDialogFragment.kt
+++ b/ui/src/main/java/org/amnezia/awg/fragment/AppListDialogFragment.kt
@@ -48,6 +48,9 @@ class AppListDialogFragment : DialogFragment() {
                     val packageInfos = getPackagesHoldingPermissions(pm, arrayOf(Manifest.permission.INTERNET))
                     packageInfos.forEach {
                         val packageName = it.packageName
+                        // Only show applications that have launcher activities
+                        if (pm.getLaunchIntentForPackage(packageName) == null)
+                            return@forEach
                         val appInfo = it.applicationInfo
                         val appData =
                             ApplicationData(appInfo.loadIcon(pm), appInfo.loadLabel(pm).toString(), packageName, currentlySelectedApps.contains(packageName))


### PR DESCRIPTION
## Summary
- filter apps with no launcher activity from the App List dialog

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684abe31648083268bf23a2608f63e0a