### PR TITLE
Adapt AccountFragment to new subscriptions

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -38,7 +38,15 @@ class AccountFragment : Fragment() {
     private var selectedServerId: String? = null
     private var selectedServerName: String? = null
     private var serverList: List<Pair<String, String>> = listOf()
+    private var subscriptions: List<Subscription> = emptyList()
     private var qrPollingTimer: Timer? = null
+
+    private data class Subscription(
+        val id: String,
+        val name: String,
+        val expires: String?,
+        val active: Boolean
+    )
 
     private val qrScanLauncher = registerForActivityResult(
         androidx.activity.result.contract.ActivityResultContracts.StartActivityForResult()
@@ -125,8 +133,7 @@ class AccountFragment : Fragment() {
                 view,
                 prefs.getString("username", "") ?: "",
                 prefs.getString("photo_url", null),
-                "",
-                ""
+                subscriptions
             )
             loadServersAndProfileUI(view)
         } else {
@@ -189,12 +196,12 @@ class AccountFragment : Fragment() {
             override fun onItemSelected(parent: AdapterView<*>, v: View?, position: Int, id: Long) {
                 selectedServerId = serverList[position].first
                 selectedServerName = serverList[position].second
-                btnDownload.isEnabled = true
+                updateDownloadButtonState(view)
             }
             override fun onNothingSelected(parent: AdapterView<*>) {
                 selectedServerId = null
                 selectedServerName = null
-                btnDownload.isEnabled = false
+                updateDownloadButtonState(view)
             }
         }
         spinner.visibility = View.VISIBLE
@@ -233,14 +240,25 @@ class AccountFragment : Fragment() {
                     } else if (response.isSuccessful) {
                         try {
                             val obj = JSONObject(resp)
-                            val status = obj.optString("status", "unknown")
-                            val expDateStr = obj.optString("expiration_date", "")
+                            val subsArr = obj.optJSONArray("subscriptions") ?: JSONArray()
+                            val parsed = mutableListOf<Subscription>()
+                            for (i in 0 until subsArr.length()) {
+                                val s = subsArr.getJSONObject(i)
+                                parsed.add(
+                                    Subscription(
+                                        s.optString("id"),
+                                        s.optString("name"),
+                                        s.optString("expires"),
+                                        s.optBoolean("active")
+                                    )
+                                )
+                            }
+                            subscriptions = parsed
                             val username = obj.optString("client_name", prefs.getString("username", "") ?: "")
                             val photoUrl = obj.optString("photo_url", null)
                             prefs.edit().putString("username", username).apply()
                             if (!photoUrl.isNullOrEmpty()) prefs.edit().putString("photo_url", photoUrl).apply()
-                            showAccountScreen(view, username, photoUrl, status, expDateStr)
-                            // Важно сразу синхронизировать туннели после получения профиля
+                            showAccountScreen(view, username, photoUrl, subscriptions)
                             syncTunnelsWithProfile()
                         } catch (e: Exception) {
                             Toast.makeText(requireContext(), "Ошибка обработки профиля", Toast.LENGTH_SHORT).show()
@@ -267,7 +285,7 @@ class AccountFragment : Fragment() {
         view.findViewById<ImageView>(R.id.avatar_image).setImageResource(R.drawable.ic_avatar_placeholder)
     }
 
-    private fun showAccountScreen(view: View, username: String, photoUrl: String?, status: String, expDateStr: String?) {
+    private fun showAccountScreen(view: View, username: String, photoUrl: String?, subs: List<Subscription>) {
         view.findViewById<Button>(R.id.btn_login_telegram).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_logout).visibility = View.VISIBLE
         view.findViewById<ImageView>(R.id.qr_code_image).visibility = View.GONE
@@ -284,26 +302,41 @@ class AccountFragment : Fragment() {
         } else {
             avatarImage.setImageResource(R.drawable.ic_avatar_placeholder)
         }
-        view.findViewById<Button>(R.id.btn_download).visibility = if (status == "active") View.VISIBLE else View.GONE
-        view.findViewById<Button>(R.id.btn_renew).visibility = if (status != "active") View.VISIBLE else View.GONE
+        val btnDownload = view.findViewById<Button>(R.id.btn_download)
+        val btnRenew = view.findViewById<Button>(R.id.btn_renew)
+        btnDownload.visibility = if (subs.isNotEmpty()) View.VISIBLE else View.GONE
+        btnRenew.visibility = if (subs.any { !it.active }) View.VISIBLE else View.GONE
         view.findViewById<TextView>(R.id.text_current_user).text = "Ваш логин: $username"
-        view.findViewById<TextView>(R.id.status_text).text =
-            when (status) {
-                "revoked" -> "Доступ к конфигу заблокирован. Оплатите подписку для восстановления."
-                "expired" -> "Срок действия подписки истёк. Оплатите для получения нового конфига."
-                "active" -> "Скачайте конфиг для автоматического импорта в приложение"
-                else -> "Статус аккаунта: $status"
+        val info = if (subs.isEmpty()) {
+            "Нет подписок"
+        } else {
+            subs.joinToString("\n") { s ->
+                if (s.active) {
+                    val days = s.expires?.let { ex ->
+                        try {
+                            val fixed = ex.replace("T", " ").substring(0, 19)
+                            val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
+                            val exp = sdf.parse(fixed)
+                            val now = Date()
+                            val d = ((exp.time - now.time) / (1000 * 60 * 60 * 24)).toInt()
+                            " (дней до окончания: $d)"
+                        } catch (_: Exception) { "" }
+                    } ?: ""
+                    "${s.name}: активна$days"
+                } else {
+                    "${s.name}: неактивна"
+                }
             }
-        view.findViewById<TextView>(R.id.text_expiration).text = expDateStr?.let {
-            if (status == "active" && it.isNotEmpty()) {
-                val fixed = it.replace("T", " ").substring(0, 19)
-                val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.getDefault())
-                val expDate = sdf.parse(fixed)
-                val now = Date()
-                val daysLeft = ((expDate.time - now.time) / (1000 * 60 * 60 * 24)).toInt()
-                "Дней до окончания: $daysLeft"
-            } else ""
-        } ?: ""
+        }
+        view.findViewById<TextView>(R.id.status_text).text = info
+        view.findViewById<TextView>(R.id.text_expiration).text = ""
+        updateDownloadButtonState(view)
+    }
+
+    private fun updateDownloadButtonState(view: View) {
+        val btn = view.findViewById<Button>(R.id.btn_download)
+        val id = selectedServerId
+        btn.isEnabled = id != null && subscriptions.any { it.id == id && it.active }
     }
 
     private fun setLoading(loading: Boolean) {
@@ -343,6 +376,12 @@ private fun afterLogout(view: View) {
         val token = prefs.getString("token", null)
         if (token == null) {
             Toast.makeText(requireContext(), "Войдите через Telegram", Toast.LENGTH_SHORT).show()
+            setLoading(false)
+            return
+        }
+        val sub = subscriptions.firstOrNull { it.id == serverId }
+        if (sub == null || !sub.active) {
+            Toast.makeText(requireContext(), "Подписка не активна для выбранной локации", Toast.LENGTH_SHORT).show()
             setLoading(false)
             return
         }


### PR DESCRIPTION
## Summary
- parse subscriptions as objects in `AccountFragment`
- display list of subscriptions and expiration info
- enable config download only for active subscriptions
- sync tunnel list using new subscription data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d317118c083269fd35247d7c6e02f