### PR TITLE
Add onboarding screens

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -83,6 +83,8 @@ dependencies {
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.google.zxing:core:3.5.1")
     implementation("com.squareup.picasso:picasso:2.71828")
+    implementation("androidx.recyclerview:recyclerview:1.3.2")
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
 implementation("com.squareup.okhttp3:logging-interceptor:4.10.0") // опционально
 
 

--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -17,6 +17,7 @@ import pw.idrug.connections.fragment.TunnelDetailFragment
 import pw.idrug.connections.fragment.TunnelEditorFragment
 import pw.idrug.connections.fragment.TunnelListFragment
 import pw.idrug.connections.fragment.AccountFragment
+import pw.idrug.connections.onboarding.OnboardingFragment
 import pw.idrug.connections.model.ObservableTunnel
 
 /**
@@ -98,6 +99,11 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
                 .replace(R.id.fragment_container, fragment)
                 .commit()
             bottomNavigation?.selectedItemId = R.id.nav_vpn
+
+            supportFragmentManager.beginTransaction()
+                .add(R.id.fragment_container, pw.idrug.connections.onboarding.OnboardingFragment())
+                .addToBackStack(null)
+                .commit()
         }
     }
 

--- a/ui/src/main/java/pw/idrug/connections/onboarding/OnboardAdapter.kt
+++ b/ui/src/main/java/pw/idrug/connections/onboarding/OnboardAdapter.kt
@@ -1,0 +1,32 @@
+package pw.idrug.connections.onboarding
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import pw.idrug.connections.R
+
+data class OnboardPage(val emoji: String, val title: String, val text: String)
+
+class OnboardAdapter(private val items: List<OnboardPage>) : RecyclerView.Adapter<OnboardAdapter.OnboardVH>() {
+    class OnboardVH(itemView: View) : RecyclerView.ViewHolder(itemView) {
+        val emoji: TextView = itemView.findViewById(R.id.img_onboard)
+        val title: TextView = itemView.findViewById(R.id.title_onboard)
+        val text: TextView = itemView.findViewById(R.id.text_onboard)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): OnboardVH {
+        val v = LayoutInflater.from(parent.context).inflate(R.layout.item_onboard_card, parent, false)
+        return OnboardVH(v)
+    }
+
+    override fun onBindViewHolder(holder: OnboardVH, position: Int) {
+        val item = items[position]
+        holder.emoji.text = item.emoji
+        holder.title.text = item.title
+        holder.text.text = item.text
+    }
+
+    override fun getItemCount() = items.size
+}

--- a/ui/src/main/java/pw/idrug/connections/onboarding/OnboardingFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/onboarding/OnboardingFragment.kt
@@ -1,0 +1,46 @@
+package pw.idrug.connections.onboarding
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.widget.ViewPager2
+import pw.idrug.connections.R
+
+class OnboardingFragment : Fragment() {
+
+    private val onboardPages = listOf(
+        OnboardPage("🔒", "Anonymous & Secure", "iDrug VPN hides your real IP and encrypts your data."),
+        OnboardPage("⚡", "Fast Servers", "Connect instantly, no speed limits. Choose server location."),
+        OnboardPage("🎮", "Game/Streaming Mode", "No pings, no drops, for all your devices."),
+        OnboardPage("💸", "Pay Any Way", "Crypto, card, whatever. Instant setup, 24/7 support."),
+        OnboardPage("🌙", "No Logs. Ever.", "Zero bullshit. No log storage, no tracking, period.")
+    )
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        return inflater.inflate(R.layout.fragment_onboarding, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val pager = view.findViewById<ViewPager2>(R.id.onboard_pager)
+        pager.adapter = OnboardAdapter(onboardPages)
+
+        val btnNext = view.findViewById<Button>(R.id.btn_onboard_next)
+        btnNext.setOnClickListener {
+            if (pager.currentItem < onboardPages.size - 1) {
+                pager.currentItem += 1
+            } else {
+                // TODO: переход к логину/главному экрану
+                requireActivity().supportFragmentManager.popBackStack()
+            }
+        }
+
+        pager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                btnNext.text = if (position == onboardPages.lastIndex) "Начать" else "Далее"
+            }
+        })
+    }
+}

--- a/ui/src/main/res/layout/fragment_onboarding.xml
+++ b/ui/src/main/res/layout/fragment_onboarding.xml
@@ -1,0 +1,21 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:background="@android:color/white"
+    android:paddingTop="32dp"
+    android:paddingBottom="32dp"
+    android:gravity="center_horizontal">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/onboard_pager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1"/>
+
+    <Button
+        android:id="@+id/btn_onboard_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="Start"
+        android:layout_margin="16dp"/>
+</LinearLayout>

--- a/ui/src/main/res/layout/item_onboard_card.xml
+++ b/ui/src/main/res/layout/item_onboard_card.xml
@@ -1,0 +1,33 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent" android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="32dp">
+
+    <TextView
+        android:id="@+id/img_onboard"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="🔒"
+        android:textSize="72sp"
+        android:gravity="center"
+        android:layout_marginBottom="16dp"/>
+
+    <TextView
+        android:id="@+id/title_onboard"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Welcome!"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:gravity="center"/>
+
+    <TextView
+        android:id="@+id/text_onboard"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="iDrug VPN keeps your traffic safe."
+        android:textSize="15sp"
+        android:gravity="center"
+        android:layout_marginTop="8dp"/>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- implement onboarding screens and adapter
- show onboarding fragment on first run
- add RecyclerView and ViewPager2 dependencies

## Testing
- `./gradlew :ui:assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685d878499ac83269209a095211617b9