### PR TITLE
Add device linking via code

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -121,6 +121,12 @@
             </intent-filter>
         </activity>
 
+        <activity
+            android:name=".activity.LinkCodeActivity"
+            android:exported="true"
+            android:label="@string/link_device"
+            android:parentActivityName=".activity.MainActivity" />
+
         <provider
             android:name=".activity.LogViewerActivity$ExportedLogContentProvider"
             android:authorities="${applicationId}.exported-log"

--- a/ui/src/main/java/pw/idrug/connections/activity/LinkCodeActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/LinkCodeActivity.kt
@@ -1,0 +1,78 @@
+package pw.idrug.connections.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import okhttp3.*
+import org.json.JSONObject
+import java.io.IOException
+
+class LinkCodeActivity : AppCompatActivity() {
+    private lateinit var editCode: EditText
+    private lateinit var progress: ProgressBar
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_link_code)
+
+        editCode = findViewById(R.id.edit_code)
+        progress = findViewById(R.id.progress)
+        findViewById<Button>(R.id.btn_submit_code).setOnClickListener { submitCode() }
+    }
+
+    private fun submitCode() {
+        val code = editCode.text.toString().trim()
+        if (code.length != 6) {
+            Toast.makeText(this, R.string.enter_code, Toast.LENGTH_SHORT).show()
+            return
+        }
+        progress.visibility = View.VISIBLE
+        linkAccountWithCode(code) { success, token, username, message ->
+            runOnUiThread {
+                progress.visibility = View.GONE
+                if (success && token != null && username != null) {
+                    val prefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
+                    prefs.edit().putString("token", token).putString("username", username).apply()
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                } else {
+                    Toast.makeText(this, message ?: getString(R.string.login_via_telegram_or_qr), Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    private fun linkAccountWithCode(code: String, callback: (Boolean, String?, String?, String?) -> Unit) {
+        val client = OkHttpClient()
+        val body = FormBody.Builder().add("code", code).build()
+        val request = Request.Builder()
+            .url("https://idrug.pw/api/linking/consume")
+            .post(body)
+            .build()
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                callback(false, null, null, e.message)
+            }
+            override fun onResponse(call: Call, response: Response) {
+                if (response.isSuccessful) {
+                    val obj = JSONObject(response.body?.string() ?: "{}")
+                    val jwt = obj.optString("jwt", null)
+                    val username = obj.optString("username", null)
+                    if (!jwt.isNullOrEmpty() && !username.isNullOrEmpty()) {
+                        callback(true, jwt, username, null)
+                    } else {
+                        callback(false, null, null, "Invalid response")
+                    }
+                } else {
+                    callback(false, null, null, "Code invalid or expired")
+                }
+            }
+        })
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -10,6 +10,10 @@ import android.os.Handler
 import android.os.Looper
 import android.view.*
 import android.widget.*
+import android.os.CountDownTimer
+import android.widget.LinearLayout
+import android.widget.TextView
+import android.view.Gravity
 import androidx.fragment.app.Fragment
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.qrcode.QRCodeWriter
@@ -125,6 +129,9 @@ class AccountFragment : Fragment() {
         }
         view.findViewById<Button>(R.id.btn_download).setOnClickListener {
             handleDownloadConfig(view)
+        }
+        view.findViewById<Button>(R.id.btn_link_device).setOnClickListener {
+            showLinkDeviceDialog()
         }
         view.findViewById<Button>(R.id.btn_renew).setOnClickListener {
             setLoading(true)
@@ -294,6 +301,7 @@ class AccountFragment : Fragment() {
 
     private fun showLoginScreen(view: View) {
         view.findViewById<Button>(R.id.btn_login_telegram).visibility = View.VISIBLE
+        view.findViewById<Button>(R.id.btn_link_device).visibility = View.VISIBLE
         view.findViewById<Button>(R.id.btn_download).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_renew).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_logout).visibility = View.GONE
@@ -308,6 +316,7 @@ class AccountFragment : Fragment() {
 
     private fun showAccountScreen(view: View, username: String, photoUrl: String?, subs: List<Subscription>) {
         view.findViewById<Button>(R.id.btn_login_telegram).visibility = View.GONE
+        view.findViewById<Button>(R.id.btn_link_device).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_logout).visibility = View.VISIBLE
         view.findViewById<ImageView>(R.id.qr_code_image).visibility = View.GONE
         view.findViewById<Spinner>(R.id.spinner_server).visibility = View.VISIBLE
@@ -617,6 +626,72 @@ class AccountFragment : Fragment() {
         } catch (e: Exception) {
             Toast.makeText(requireContext(), "Unable to open Telegram", Toast.LENGTH_SHORT).show()
         }
+    }
+
+    private fun showLinkDeviceDialog() {
+        val dialog = android.app.AlertDialog.Builder(requireContext())
+        dialog.setTitle(getString(R.string.link_device))
+
+        val layout = LinearLayout(requireContext())
+        layout.orientation = LinearLayout.VERTICAL
+        layout.setPadding(48, 24, 48, 24)
+
+        val codeText = TextView(requireContext())
+        codeText.textSize = 32f
+        codeText.gravity = Gravity.CENTER
+        codeText.text = "------"
+
+        val timerText = TextView(requireContext())
+        timerText.textSize = 14f
+        timerText.gravity = Gravity.CENTER
+        timerText.setPadding(0, 8, 0, 0)
+
+        layout.addView(codeText)
+        layout.addView(timerText)
+        dialog.setView(layout)
+
+        var countdownTimer: CountDownTimer? = null
+
+        dialog.setNegativeButton(android.R.string.cancel) { dlg, _ ->
+            countdownTimer?.cancel()
+            dlg.dismiss()
+        }
+
+        dialog.show()
+
+        val token = prefs.getString("token", null) ?: return
+        val client = OkHttpClient()
+        val req = Request.Builder()
+            .url("https://idrug.pw/api/linking/generate")
+            .addHeader("Authorization", "Bearer $token")
+            .post(FormBody.Builder().build())
+            .build()
+        client.newCall(req).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                safeUi { codeText.text = "Error" }
+            }
+            override fun onResponse(call: Call, response: Response) {
+                val body = response.body?.string() ?: ""
+                if (!response.isSuccessful) {
+                    safeUi { codeText.text = "Error" }
+                    return
+                }
+                val obj = JSONObject(body)
+                val code = obj.optString("link_code")
+                val ttl = obj.optInt("ttl", 180)
+                safeUi {
+                    codeText.text = code
+                    countdownTimer = object : CountDownTimer((ttl * 1000).toLong(), 1000) {
+                        override fun onTick(millisUntilFinished: Long) {
+                            timerText.text = "Expires in ${millisUntilFinished / 1000}s"
+                        }
+                        override fun onFinish() {
+                            timerText.text = getString(R.string.login_via_telegram_or_qr)
+                        }
+                    }.start()
+                }
+            }
+        })
     }
 
     private fun handleDeepLink(intent: Intent?) {

--- a/ui/src/main/res/layout/activity_link_code.xml
+++ b/ui/src/main/res/layout/activity_link_code.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/code_login_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:paddingBottom="16dp" />
+
+    <EditText
+        android:id="@+id/edit_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        android:hint="@string/enter_code"
+        android:maxLength="6"
+        android:gravity="center"
+        android:textSize="24sp" />
+
+    <Button
+        android:id="@+id/btn_submit_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/submit_code"
+        android:layout_marginTop="16dp" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:visibility="gone" />
+
+</LinearLayout>

--- a/ui/src/main/res/layout/fragment_account.xml
+++ b/ui/src/main/res/layout/fragment_account.xml
@@ -61,6 +61,12 @@
                 android:layout_height="wrap_content"
                 android:text="@string/login_via_telegram" />
 
+            <Button
+                android:id="@+id/btn_link_device"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/link_device" />
+
 
             <ImageView
                 android:id="@+id/qr_code_image"

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -287,6 +287,10 @@
     <string name="choose_server">Выберите сервер</string>
     <string name="download_config">Скачать конфиг</string>
     <string name="renew_subscription">Продлить подписку</string>
+    <string name="link_device">Привязать устройство</string>
+    <string name="enter_code">Введите код</string>
+    <string name="submit_code">Войти</string>
+    <string name="code_login_title">Введите 6-значный код</string>
     <string name="logout">Выйти</string>
     <string name="nav_account_title">Личный кабинет</string>
     <string name="update_application_title">Обновить приложение</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -266,6 +266,10 @@
     <string name="choose_server">Choose server</string>
     <string name="download_config">Download config</string>
     <string name="renew_subscription">Renew subscription</string>
+    <string name="link_device">Link device</string>
+    <string name="enter_code">Enter code</string>
+    <string name="submit_code">Link</string>
+    <string name="code_login_title">Enter 6-digit code</string>
     <string name="logout">Logout</string>
     <string name="nav_account_title">Account</string>
     <string name="update_application_title">Update application</string>


### PR DESCRIPTION
## Summary
- allow generating single-use device link codes from `AccountFragment`
- add `LinkCodeActivity` for entering the code on another device
- show/hide new `Link device` button in account layout
- wire activity in manifest and add strings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e710bfc108326a318b73590c2e0e3