### PR TITLE
Add interaction blocker during profile loading

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -393,6 +393,7 @@ class AccountFragment : Fragment() {
 
     private fun setLoading(loading: Boolean) {
         view?.findViewById<View>(R.id.loading_overlay)?.visibility = if (loading) View.VISIBLE else View.GONE
+        activity?.findViewById<View>(R.id.interaction_blocker)?.visibility = if (loading) View.VISIBLE else View.GONE
     }
 
     private fun afterLogout(view: View) {

--- a/ui/src/main/res/layout-sw600dp/main_activity.xml
+++ b/ui/src/main/res/layout-sw600dp/main_activity.xml
@@ -28,6 +28,14 @@
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="3" />
-    </LinearLayout>
+</LinearLayout>
+
+    <View
+        android:id="@+id/interaction_blocker"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:clickable="true"
+        android:focusable="true" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/ui/src/main/res/layout/main_activity.xml
+++ b/ui/src/main/res/layout/main_activity.xml
@@ -1,20 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/main_activity_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:layout_height="match_parent">
 
-    <FrameLayout
-        android:id="@+id/fragment_container"
+    <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_height="match_parent"
+        android:orientation="vertical">
 
-    <com.google.android.material.bottomnavigation.BottomNavigationView
-        android:id="@+id/bottom_navigation"
+        <FrameLayout
+            android:id="@+id/fragment_container"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1" />
+
+        <com.google.android.material.bottomnavigation.BottomNavigationView
+            android:id="@+id/bottom_navigation"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            app:menu="@menu/bottom_nav_menu" />
+    </LinearLayout>
+
+    <View
+        android:id="@+id/interaction_blocker"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        app:menu="@menu/bottom_nav_menu" />
-</LinearLayout>
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:clickable="true"
+        android:focusable="true" />
+</FrameLayout>


### PR DESCRIPTION
## Summary
- add full-screen `interaction_blocker` view in MainActivity layouts
- toggle the blocker together with existing loading overlay

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ee434c10483268ea037e4d50049fd