### PR TITLE
Handle invalid server location and disable nav during loads

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -36,6 +36,8 @@ import android.text.style.StyleSpan
 import android.text.style.ForegroundColorSpan
 import android.graphics.Typeface
 import android.graphics.Color
+import android.util.Log
+import com.google.android.material.bottomnavigation.BottomNavigationView
 
 class AccountFragment : Fragment() {
 
@@ -61,13 +63,20 @@ class AccountFragment : Fragment() {
     private var subscriptions: List<Subscription> = emptyList()
 
     // --- Локализация названия сервера ---
-    private fun getServerName(location: String): String {
+    private fun getServerName(location: String?): String {
+        if (location.isNullOrBlank()) {
+            Log.w("AccountFragment", "getServerName: empty or null location")
+            return "Unknown"
+        }
         return when (location) {
             "germany" -> getString(R.string.server_germany)
             "multihop" -> getString(R.string.server_multihop_germany)
             "bulgaria" -> getString(R.string.server_bulgaria)
             "madrid" -> getString(R.string.server_madrid)
-            else -> location
+            else -> {
+                Log.w("AccountFragment", "getServerName: unrecognized location $location")
+                location
+            }
         }
     }
 
@@ -393,6 +402,7 @@ class AccountFragment : Fragment() {
 
     private fun setLoading(loading: Boolean) {
         view?.findViewById<View>(R.id.loading_overlay)?.visibility = if (loading) View.VISIBLE else View.GONE
+        activity?.findViewById<BottomNavigationView>(R.id.bottom_navigation)?.isEnabled = !loading
     }
 
     private fun afterLogout(view: View) {

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -191,34 +191,34 @@ class AccountFragment : Fragment() {
         val url = "https://idrug.pw/api/servers"
         client.newCall(Request.Builder().url(url).build()).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
-                serverList = listOf(
-                    "germany" to getServerName("germany"),
-                    "multihop" to getServerName("multihop"),
-                    "bulgaria" to getServerName("bulgaria"),
-                    "madrid" to getServerName("madrid")
-                )
                 safeUi {
-                    setupServerSpinner(view)
-                    loadProfileAndSetupUI(view)
-                }
-            }
-            override fun onResponse(call: Call, response: Response) {
-                if (response.isSuccessful) {
-                    val arr = JSONArray(response.body?.string() ?: "[]")
-                    serverList = List(arr.length()) {
-                        val obj = arr.getJSONObject(it)
-                        val id = obj.getString("id")
-                        id to getServerName(id)
-                    }
-                } else {
                     serverList = listOf(
                         "germany" to getServerName("germany"),
                         "multihop" to getServerName("multihop"),
                         "bulgaria" to getServerName("bulgaria"),
                         "madrid" to getServerName("madrid")
                     )
+                    setupServerSpinner(view)
+                    loadProfileAndSetupUI(view)
                 }
+            }
+            override fun onResponse(call: Call, response: Response) {
                 safeUi {
+                    if (response.isSuccessful) {
+                        val arr = JSONArray(response.body?.string() ?: "[]")
+                        serverList = List(arr.length()) {
+                            val obj = arr.getJSONObject(it)
+                            val id = obj.getString("id")
+                            id to getServerName(id)
+                        }
+                    } else {
+                        serverList = listOf(
+                            "germany" to getServerName("germany"),
+                            "multihop" to getServerName("multihop"),
+                            "bulgaria" to getServerName("bulgaria"),
+                            "madrid" to getServerName("madrid")
+                        )
+                    }
                     setupServerSpinner(view)
                     loadProfileAndSetupUI(view)
                 }


### PR DESCRIPTION
## Summary
- make `AccountFragment.getServerName` null-safe and add logging
- disable BottomNavigationView while loading profile or servers
- include required imports

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fb88bb84883268417404732ff1253