### PR TITLE
Implement VPN kill-switch

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -144,6 +144,19 @@
         </receiver>
 
         <receiver
+            android:name=".ReconnectReceiver"
+            android:exported="false" />
+
+        <service
+            android:name=".KillSwitchService"
+            android:permission="android.permission.BIND_VPN_SERVICE"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.net.VpnService" />
+            </intent-filter>
+        </service>
+
+        <receiver
             android:name=".model.TunnelManager$IntentReceiver"
             android:exported="true"
             android:permission="${applicationId}.permission.CONTROL_TUNNELS">

--- a/ui/src/main/java/pw/idrug/connections/KillSwitchNotification.kt
+++ b/ui/src/main/java/pw/idrug/connections/KillSwitchNotification.kt
@@ -1,0 +1,40 @@
+package pw.idrug.connections
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Context
+import android.content.Intent
+import androidx.core.app.NotificationCompat
+
+object KillSwitchNotification {
+    private const val CHANNEL_ID = "killswitch"
+
+    fun create(context: Context): Notification {
+        val nm = context.getSystemService(NotificationManager::class.java)
+        if (nm.getNotificationChannel(CHANNEL_ID) == null) {
+            val ch = NotificationChannel(
+                CHANNEL_ID,
+                "Kill-Switch",
+                NotificationManager.IMPORTANCE_HIGH
+            )
+            nm.createNotificationChannel(ch)
+        }
+        val reconnectIntent = PendingIntent.getBroadcast(
+            context,
+            0,
+            Intent(context, ReconnectReceiver::class.java),
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        return NotificationCompat.Builder(context, CHANNEL_ID)
+            .setContentTitle(context.getString(R.string.killswitch_active))
+            .setSmallIcon(R.drawable.ic_notification)
+            .addAction(
+                R.drawable.ic_notification,
+                context.getString(R.string.reconnect),
+                reconnectIntent
+            )
+            .build()
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/KillSwitchService.kt
+++ b/ui/src/main/java/pw/idrug/connections/KillSwitchService.kt
@@ -1,0 +1,33 @@
+package pw.idrug.connections
+
+import android.app.Service
+import android.content.Intent
+import android.net.VpnService
+import android.os.ParcelFileDescriptor
+import pw.idrug.connections.util.KillSwitchPrefs
+
+class KillSwitchService : VpnService() {
+    private var vpnInterface: ParcelFileDescriptor? = null
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        startForeground(1, KillSwitchNotification.create(this))
+        val builder = Builder().setSession("KillSwitch")
+        val whitelist = KillSwitchPrefs.getWhitelist() + packageName
+        packageManager.getInstalledApplications(0)
+            .map { it.packageName }
+            .filter { it !in whitelist }
+            .forEach {
+                try { builder.addDisallowedApplication(it) } catch (_: Exception) {}
+            }
+        builder.addAddress("10.0.0.2", 32)
+        vpnInterface?.close()
+        vpnInterface = builder.establish()
+        return Service.START_STICKY
+    }
+
+    override fun onDestroy() {
+        vpnInterface?.close()
+        vpnInterface = null
+        super.onDestroy()
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/ReconnectReceiver.kt
+++ b/ui/src/main/java/pw/idrug/connections/ReconnectReceiver.kt
@@ -1,0 +1,16 @@
+package pw.idrug.connections
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import pw.idrug.connections.backend.Tunnel
+import pw.idrug.connections.util.applicationScope
+import kotlinx.coroutines.launch
+
+class ReconnectReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent?) {
+        applicationScope.launch {
+            Application.getTunnelManager().lastUsedTunnel?.setStateAsync(Tunnel.State.UP)
+        }
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/model/TunnelManager.kt
+++ b/ui/src/main/java/pw/idrug/connections/model/TunnelManager.kt
@@ -25,6 +25,7 @@ import pw.idrug.connections.util.ErrorMessages
 import pw.idrug.connections.util.UserKnobs
 import pw.idrug.connections.util.applicationScope
 import pw.idrug.connections.config.Config
+import pw.idrug.connections.KillSwitchService
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -205,10 +206,20 @@ class TunnelManager(private val configStore: ConfigStore) : BaseObservable() {
             throwable = e
         }
         tunnel.onStateChanged(newState)
+        handleKillSwitch(newState)
         saveState()
         if (throwable != null)
             throw throwable
         newState
+    }
+
+    private fun handleKillSwitch(state: Tunnel.State) {
+        val intent = Intent(context, KillSwitchService::class.java)
+        if (state == Tunnel.State.DOWN) {
+            context.startService(intent)
+        } else if (state == Tunnel.State.UP) {
+            context.stopService(intent)
+        }
     }
 
     class IntentReceiver : BroadcastReceiver() {

--- a/ui/src/main/java/pw/idrug/connections/util/KillSwitchPrefs.kt
+++ b/ui/src/main/java/pw/idrug/connections/util/KillSwitchPrefs.kt
@@ -1,0 +1,19 @@
+package pw.idrug.connections.util
+
+import android.content.Context
+import pw.idrug.connections.Application
+
+object KillSwitchPrefs {
+    private const val PREFS = "kill_switch_prefs"
+    private const val KEY_WHITELIST = "whitelist"
+
+    private val prefs get() =
+        Application.get().getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+
+    fun getWhitelist(): Set<String> =
+        prefs.getStringSet(KEY_WHITELIST, emptySet()) ?: emptySet()
+
+    fun setWhitelist(packages: Set<String>) {
+        prefs.edit().putStringSet(KEY_WHITELIST, packages).apply()
+    }
+}

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -63,6 +63,8 @@
     <string name="allow_remote_control_intents_summary_on">External apps may toggle tunnels (advanced)</string>
     <string name="allow_remote_control_intents_title">Allow remote control apps</string>
     <string name="allowed_ips">Allowed IPs</string>
+    <string name="killswitch_active">Internet access blocked</string>
+    <string name="reconnect">Reconnect</string>
     <!-- Application name updated as required -->
     <string name="app_name" translatable="false">iDrug Connections</string>
     <string name="bad_config_context">%1$s\'s %2$s</string>


### PR DESCRIPTION
## Summary
- add killswitch preferences
- implement KillSwitchService with notification and reconnect receiver
- handle kill switch logic in TunnelManager
- register service and receiver in manifest
- add strings for killswitch notification

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fc81610988326b5a207221cf92a90