### PR TITLE
Fix Firebase conflict with org.json

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -81,7 +81,6 @@ dependencies {
     implementation(libs.zxing.android.embedded)
     implementation(libs.kotlinx.coroutines.android)
     implementation("com.squareup.okhttp3:okhttp:4.10.0")
-    implementation("org.json:json:20231013")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.google.zxing:core:3.5.1")
     implementation("com.squareup.picasso:picasso:2.71828")


### PR DESCRIPTION
## Summary
- remove external `org.json` dependency to rely on Android built‑in implementation

## Testing
- `./gradlew help --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe2c458bc8326b1b77c013684b368