### PR TITLE
Refactor leftover amnezia names

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
-amneziawgVersionCode=5
-amneziawgVersionName=1.1.2
-amneziawgPackageName=pw.idrug.connections
+idrugconnectionsVersionCode=5
+idrugconnectionsVersionName=1.1.2
+idrugconnectionsPackageName=pw.idrug.connections
 
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit

--- a/tunnel/build.gradle.kts
+++ b/tunnel/build.gradle.kts
@@ -2,7 +2,7 @@
 
 import org.gradle.api.tasks.testing.logging.TestLogEvent
 
-val pkg: String = providers.gradleProperty("amneziawgPackageName").get()
+val pkg: String = providers.gradleProperty("idrugconnectionsPackageName").get()
 val cmakeAndroidPackageName: String = providers.environmentVariable("ANDROID_PACKAGE_NAME").getOrElse(pkg)
 
 plugins {

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -3,7 +3,7 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-val pkg: String = providers.gradleProperty("amneziawgPackageName").get()
+val pkg: String = providers.gradleProperty("idrugconnectionsPackageName").get()
 
 plugins {
     alias(libs.plugins.android.application)
@@ -22,8 +22,8 @@ android {
     defaultConfig {
         applicationId = pkg
         targetSdk = 34
-        versionCode = providers.gradleProperty("amneziawgVersionCode").get().toInt()
-        versionName = providers.gradleProperty("amneziawgVersionName").get()
+        versionCode = providers.gradleProperty("idrugconnectionsVersionCode").get().toInt()
+        versionName = providers.gradleProperty("idrugconnectionsVersionName").get()
         buildConfigField("int", "MIN_SDK_VERSION", minSdk.toString())
     }
     compileOptions {

--- a/ui/src/main/java/pw/idrug/connections/activity/LogViewerActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/LogViewerActivity.kt
@@ -171,7 +171,7 @@ class LogViewerActivity : AppCompatActivity() {
         var outputFile: DownloadsFileSaver.DownloadsFile? = null
         withContext(Dispatchers.IO) {
             try {
-                outputFile = downloadsFileSaver.save("amneziawg-log.txt", "text/plain", true)
+        outputFile = downloadsFileSaver.save("idrugconnections-log.txt", "text/plain", true)
                 outputFile?.outputStream?.write(rawLogBytes())
             } catch (e: Throwable) {
                 outputFile?.delete()
@@ -353,7 +353,7 @@ class LogViewerActivity : AppCompatActivity() {
         override fun query(uri: Uri, projection: Array<out String>?, selection: String?, selectionArgs: Array<out String>?, sortOrder: String?): Cursor? =
             logForUri(uri)?.let {
                 val m = MatrixCursor(arrayOf(android.provider.OpenableColumns.DISPLAY_NAME, android.provider.OpenableColumns.SIZE), 1)
-                m.addRow(arrayOf("amneziawg-log.txt", it.size.toLong()))
+                m.addRow(arrayOf("idrugconnections-log.txt", it.size.toLong()))
                 m
             }
 

--- a/ui/src/main/java/pw/idrug/connections/preference/ZipExporterPreference.kt
+++ b/ui/src/main/java/pw/idrug/connections/preference/ZipExporterPreference.kt
@@ -43,7 +43,7 @@ class ZipExporterPreference(context: Context, attrs: AttributeSet?) : Preference
                     if (configs.isEmpty()) {
                         throw IllegalArgumentException(context.getString(R.string.no_tunnels_error))
                     }
-                    val outputFile = downloadsFileSaver.save("amneziawg-export.zip", "application/zip", true)
+                    val outputFile = downloadsFileSaver.save("idrugconnections-export.zip", "application/zip", true)
                     if (outputFile == null) {
                         withContext(Dispatchers.Main.immediate) {
                             isEnabled = true

--- a/ui/src/main/res/layout/tunnel_detail_fragment.xml
+++ b/ui/src/main/res/layout/tunnel_detail_fragment.xml
@@ -483,7 +483,7 @@
                         tools:text="1766607858" />
 
                     <androidx.constraintlayout.widget.Barrier
-                        android:id="@+id/amnezia_barrier"
+                        android:id="@+id/idrugconnections_barrier"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
                         app:barrierDirection="bottom"
@@ -497,7 +497,7 @@
                         android:labelFor="@+id/applications_text"
                         android:text="@string/applications"
                         app:layout_constraintStart_toStartOf="parent"
-                        app:layout_constraintTop_toBottomOf="@+id/amnezia_barrier" />
+                        app:layout_constraintTop_toBottomOf="@+id/idrugconnections_barrier" />
 
                     <TextView
                         android:id="@+id/applications_text"


### PR DESCRIPTION
## Summary
- rename remaining amnezia property keys to idrugconnections
- update Gradle files to use the new keys
- rename exported log/zip files
- rename layout barrier id

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe654a2f08326be96f761df93dde8