### PR TITLE
Improve OTA update mechanism

### DIFF
--- a/ui/src/debug/res/values/strings.xml
+++ b/ui/src/debug/res/values/strings.xml
@@ -267,6 +267,8 @@
     <string name="nav_account_title">Account</string>
     <string name="update_application_title">Update application</string>
     <string name="update_application_summary">Check for a new version and update the app</string>
+    <string name="update_check_error">Update check failed: %s</string>
+    <string name="update_no_new_version">Application is already up to date</string>
     <string name="your_username">Your username: %s</string>
     <string name="import_disclaimer">Ensure that you obtained the configuration file from a trusted source.
     

--- a/ui/src/main/java/pw/idrug/connections/activity/SettingsActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/SettingsActivity.kt
@@ -9,6 +9,10 @@ import android.os.Environment
 import android.provider.Settings
 import android.view.MenuItem
 import android.widget.Toast
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import pw.idrug.connections.BuildConfig
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.FileProvider
 import androidx.fragment.app.commit
@@ -115,50 +119,74 @@ class SettingsActivity : AppCompatActivity() {
             }
         }
 
-private fun checkForOtaUpdate() {
-    try {
-        val context = requireContext()
-        val url = "https://idrug.pw/ota/iDrugConnections.apk"
-        val fileName = "iDrugConnections.apk"
-        val file = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), fileName)
-        if (file.exists()) {
-            val deleted = file.delete()
-            if (!deleted) {
-                Toast.makeText(context, context.getString(R.string.update_delete_old_failed), Toast.LENGTH_SHORT).show()
+        private fun checkForOtaUpdate() {
+            lifecycleScope.launch {
+                val context = requireContext()
+                val manifestUrl = "https://idrug.pw/ota/manifest.json"
+                try {
+                    val client = OkHttpClient()
+                    val request = Request.Builder().url(manifestUrl).build()
+                    val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+                    if (!response.isSuccessful) {
+                        Toast.makeText(context, getString(R.string.update_check_error, response.code), Toast.LENGTH_LONG).show()
+                        return@launch
+                    }
+                    val json = JSONObject(response.body?.string() ?: "{}")
+                    val versionCode = json.optInt("versionCode", -1)
+                    val apkUrl = json.optString("apkUrl")
+                    if (versionCode <= BuildConfig.VERSION_CODE || apkUrl.isBlank()) {
+                        Toast.makeText(context, getString(R.string.update_no_new_version), Toast.LENGTH_SHORT).show()
+                        return@launch
+                    }
+                    downloadApk(apkUrl)
+                } catch (e: Exception) {
+                    Toast.makeText(context, getString(R.string.update_check_error, e.localizedMessage ?: ""), Toast.LENGTH_LONG).show()
+                }
             }
         }
 
-        val request = DownloadManager.Request(Uri.parse(url))
-            .setTitle("Downloading update")
-            .setDescription("Downloading new application version")
-            .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-            .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
-            .setAllowedOverMetered(true)
-            .setAllowedOverRoaming(true)
+        private fun downloadApk(url: String) {
+            try {
+                val context = requireContext()
+                val fileName = "iDrugConnections.apk"
+                val file = File(context.getExternalFilesDir(Environment.DIRECTORY_DOWNLOADS), fileName)
+                if (file.exists()) {
+                    val deleted = file.delete()
+                    if (!deleted) {
+                        Toast.makeText(context, context.getString(R.string.update_delete_old_failed), Toast.LENGTH_SHORT).show()
+                    }
+                }
 
-        val manager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
-        downloadId = manager.enqueue(request)
+                val request = DownloadManager.Request(Uri.parse(url))
+                    .setTitle("Downloading update")
+                    .setDescription("Downloading new application version")
+                    .setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
+                    .setDestinationInExternalFilesDir(context, Environment.DIRECTORY_DOWNLOADS, fileName)
+                    .setAllowedOverMetered(true)
+                    .setAllowedOverRoaming(true)
 
-        Toast.makeText(context, context.getString(R.string.update_download_started), Toast.LENGTH_SHORT).show()
+                val manager = context.getSystemService(Context.DOWNLOAD_SERVICE) as DownloadManager
+                downloadId = manager.enqueue(request)
 
-        // Corrected call:
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            context.registerReceiver(
-                downloadReceiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
-                Context.RECEIVER_NOT_EXPORTED
-            )
-        } else {
-            context.registerReceiver(
-                downloadReceiver,
-                IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
-            )
+                Toast.makeText(context, context.getString(R.string.update_download_started), Toast.LENGTH_SHORT).show()
+
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    context.registerReceiver(
+                        downloadReceiver,
+                        IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE),
+                        Context.RECEIVER_NOT_EXPORTED
+                    )
+                } else {
+                    context.registerReceiver(
+                        downloadReceiver,
+                        IntentFilter(DownloadManager.ACTION_DOWNLOAD_COMPLETE)
+                    )
+                }
+            } catch (e: Exception) {
+                Toast.makeText(requireContext(), getString(R.string.update_start_error, e.localizedMessage), Toast.LENGTH_LONG).show()
+                e.printStackTrace()
+            }
         }
-    } catch (e: Exception) {
-        Toast.makeText(requireContext(), getString(R.string.update_start_error, e.localizedMessage), Toast.LENGTH_LONG).show()
-        e.printStackTrace()
-    }
-}
 
 
         private fun installApk() {

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -289,6 +289,8 @@
     <string name="update_delete_old_failed">Failed to delete old update file</string>
     <string name="update_download_started">Update download started</string>
     <string name="update_start_error">Error starting update: %s</string>
+    <string name="update_check_error">Update check failed: %s</string>
+    <string name="update_no_new_version">Application is already up to date</string>
     <string name="apk_not_found">APK not found!</string>
     <string name="permission_unknown_sources">Grant permission to install from unknown sources and try again</string>
     <string name="apk_open_error">Failed to open APK for installation: %s</string>


### PR DESCRIPTION
## Summary
- check remote manifest before downloading update
- notify user if no new version is available
- add extra update strings for status messages

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fe151adb083268d208476ab54c41b