### PR TITLE
Implement TV linking flow

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -53,13 +53,19 @@
             android:theme="@style/NoBackgroundTheme" />
 
         <activity
-            android:name=".activity.MainActivity"
-            android:exported="true">
+            android:name=".activity.LauncherActivity"
+            android:exported="true"
+            android:theme="@style/NoBackgroundTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".activity.MainActivity"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />
@@ -91,12 +97,7 @@
         <activity
             android:name=".activity.TvMainActivity"
             android:exported="true"
-            android:theme="@style/TvTheme">
-            <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
-                <category android:name="android.intent.category.LEANBACK_LAUNCHER" />
-            </intent-filter>
-        </activity>
+            android:theme="@style/TvTheme" />
         
         <activity
             android:name=".activity.SettingsActivity"

--- a/ui/src/main/java/pw/idrug/connections/activity/LauncherActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/LauncherActivity.kt
@@ -1,0 +1,36 @@
+package pw.idrug.connections.activity
+
+import android.app.UiModeManager
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.content.res.Configuration
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+
+class LauncherActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val prefs = getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+        val isLinked = prefs.getBoolean("is_linked", false)
+        val isTv = isTvDevice()
+
+        val target = if (isTv && !isLinked) {
+            TVLinkActivity::class.java
+        } else {
+            MainActivity::class.java
+        }
+
+        startActivity(Intent(this, target))
+        finish()
+    }
+
+    private fun isTvDevice(): Boolean {
+        val uiModeManager = getSystemService(Context.UI_MODE_SERVICE) as UiModeManager
+        if (uiModeManager.currentModeType == Configuration.UI_MODE_TYPE_TELEVISION) {
+            return true
+        }
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/activity/TVLinkActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/TVLinkActivity.kt
@@ -1,0 +1,85 @@
+package pw.idrug.connections.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.Button
+import android.widget.EditText
+import android.widget.ProgressBar
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import okhttp3.*
+import org.json.JSONObject
+import pw.idrug.connections.R
+import java.io.IOException
+
+class TVLinkActivity : AppCompatActivity() {
+    private lateinit var editCode: EditText
+    private lateinit var progress: ProgressBar
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_tv_link)
+
+        editCode = findViewById(R.id.edit_code)
+        progress = findViewById(R.id.progress)
+        findViewById<Button>(R.id.btn_submit_code).setOnClickListener { submitCode() }
+    }
+
+    private fun submitCode() {
+        val code = editCode.text.toString().trim()
+        if (code.length != 6) {
+            Toast.makeText(this, R.string.enter_code, Toast.LENGTH_SHORT).show()
+            return
+        }
+        progress.visibility = View.VISIBLE
+        linkAccountWithCode(code) { success, token, username, message ->
+            runOnUiThread {
+                progress.visibility = View.GONE
+                if (success && token != null && username != null) {
+                    val authPrefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
+                    authPrefs.edit()
+                        .putString("token", token)
+                        .putString("username", username)
+                        .apply()
+                    getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+                        .edit().putBoolean("is_linked", true).apply()
+                    startActivity(Intent(this, MainActivity::class.java))
+                    finish()
+                } else {
+                    Toast.makeText(this, message ?: getString(R.string.login_via_telegram_or_qr), Toast.LENGTH_LONG).show()
+                }
+            }
+        }
+    }
+
+    private fun linkAccountWithCode(code: String, callback: (Boolean, String?, String?, String?) -> Unit) {
+        val client = OkHttpClient()
+        val body = FormBody.Builder().add("code", code).build()
+        val request = Request.Builder()
+            .url("https://idrug.pw/api/linking/consume")
+            .post(body)
+            .build()
+        client.newCall(request).enqueue(object : Callback {
+            override fun onFailure(call: Call, e: IOException) {
+                callback(false, null, null, getString(R.string.network_error_msg, e.message))
+            }
+
+            override fun onResponse(call: Call, response: Response) {
+                if (response.isSuccessful) {
+                    val obj = JSONObject(response.body?.string() ?: "{}")
+                    val jwt = obj.optString("jwt", null)
+                    val username = obj.optString("username", null)
+                    if (!jwt.isNullOrEmpty() && !username.isNullOrEmpty()) {
+                        callback(true, jwt, username, null)
+                    } else {
+                        callback(false, null, null, getString(R.string.invalid_response))
+                    }
+                } else {
+                    callback(false, null, null, getString(R.string.code_invalid_or_expired))
+                }
+            }
+        })
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -413,6 +413,8 @@ class AccountFragment : Fragment() {
 
     private fun afterLogout(view: View) {
         prefs.edit().clear().apply()
+        requireContext().getSharedPreferences("app_prefs", Context.MODE_PRIVATE)
+            .edit().putBoolean("is_linked", false).apply()
         MainScope().launch {
             try {
                 val tunnelManager = Application.getTunnelManager()

--- a/ui/src/main/res/layout/activity_tv_link.xml
+++ b/ui/src/main/res/layout/activity_tv_link.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/code_login_title"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:paddingBottom="16dp" />
+
+    <EditText
+        android:id="@+id/edit_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:inputType="number"
+        android:hint="@string/enter_code"
+        android:maxLength="6"
+        android:gravity="center"
+        android:textSize="24sp" />
+
+    <Button
+        android:id="@+id/btn_submit_code"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/submit_code"
+        android:layout_marginTop="16dp" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:visibility="gone" />
+
+</LinearLayout>


### PR DESCRIPTION
## Summary
- add LauncherActivity to route startup
- add TVLinkActivity for code-based linking
- show linking screen only on Android TV until linked
- reset linking flag on logout
- update manifest to use new launcher and remove old LAUNCHER filters
- provide layout for TVLinkActivity

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602211c96c83268df6824dccb285c3