### PR TITLE
Add onboarding screens

### DIFF
--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -78,6 +78,7 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.datastore.preferences)
     implementation(libs.google.material)
+    implementation("androidx.viewpager2:viewpager2:1.0.0")
     implementation(libs.zxing.android.embedded)
     implementation(libs.kotlinx.coroutines.android)
     implementation("com.squareup.okhttp3:okhttp:4.10.0")

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -53,13 +53,17 @@
             android:theme="@style/NoBackgroundTheme" />
 
         <activity
-            android:name=".activity.MainActivity"
+            android:name=".activity.OnboardingActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
-
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+        </activity>
+
+        <activity
+            android:name=".activity.MainActivity"
+            android:exported="true">
 
             <intent-filter>
                 <action android:name="android.service.quicksettings.action.QS_TILE_PREFERENCES" />

--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -34,6 +34,7 @@ import pw.idrug.connections.model.ObservableTunnel
  * editing the configuration and interface state of iDrugConnections tunnels.
  */
 class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener {
+    companion object { const val EXTRA_OPEN_ACCOUNT = "open_account" }
     private var actionBar: ActionBar? = null
     private var isTwoPaneLayout = false
     private var backPressedCallback: OnBackPressedCallback? = null
@@ -106,11 +107,11 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
             }
         }
 
-        // Open VPN tab by default
         if (savedInstanceState == null) {
-            val fragment = TunnelListFragment()
+            val openAccount = intent?.getBooleanExtra(EXTRA_OPEN_ACCOUNT, false) == true
+            val fragment: Fragment = if (openAccount) AccountFragment() else TunnelListFragment()
             val data = intent?.data
-            if (intent?.action == Intent.ACTION_VIEW && data?.scheme == "idrug" && data.host == "apps") {
+            if (!openAccount && intent?.action == Intent.ACTION_VIEW && data?.scheme == "idrug" && data.host == "apps") {
                 fragment.arguments = Bundle().apply {
                     putString(TunnelListFragment.ARG_OPEN_TUNNEL_FOR_APPS, data.lastPathSegment)
                 }
@@ -118,7 +119,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
             supportFragmentManager.beginTransaction()
                 .replace(R.id.fragment_container, fragment)
                 .commit()
-            bottomNavigation?.selectedItemId = R.id.nav_vpn
+            bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
         }
 
         // --- Получить FCM token (опционально, если вдруг надо где-то показать или залогать) ---

--- a/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
@@ -5,20 +5,24 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.commit
+import pw.idrug.connections.R
 import pw.idrug.connections.fragment.OnboardingFragment
 
 class OnboardingActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_onboarding)
+
         val prefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
         if (!prefs.getString("token", null).isNullOrEmpty()) {
             startActivity(Intent(this, MainActivity::class.java))
             finish()
             return
         }
+
         if (savedInstanceState == null) {
             supportFragmentManager.commit {
-                replace(android.R.id.content, OnboardingFragment())
+                replace(R.id.onboarding_container, OnboardingFragment())
             }
         }
     }

--- a/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
@@ -1,0 +1,25 @@
+package pw.idrug.connections.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.commit
+import pw.idrug.connections.fragment.OnboardingFragment
+
+class OnboardingActivity : AppCompatActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        val prefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
+        if (!prefs.getString("token", null).isNullOrEmpty()) {
+            startActivity(Intent(this, MainActivity::class.java))
+            finish()
+            return
+        }
+        if (savedInstanceState == null) {
+            supportFragmentManager.commit {
+                replace(android.R.id.content, OnboardingFragment())
+            }
+        }
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/fragment/OnboardingAdapter.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/OnboardingAdapter.kt
@@ -1,0 +1,33 @@
+package pw.idrug.connections.fragment
+
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.recyclerview.widget.RecyclerView
+import pw.idrug.connections.R
+
+class OnboardingAdapter(private val items: List<Item>) : RecyclerView.Adapter<OnboardingAdapter.ViewHolder>() {
+
+    data class Item(val emoji: String, val title: String, val desc: String)
+
+    class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+        val emoji: TextView = view.findViewById(R.id.text_emoji)
+        val title: TextView = view.findViewById(R.id.text_title)
+        val desc: TextView = view.findViewById(R.id.text_desc)
+    }
+
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+        val view = LayoutInflater.from(parent.context).inflate(R.layout.item_onboard_card, parent, false)
+        return ViewHolder(view)
+    }
+
+    override fun getItemCount(): Int = items.size
+
+    override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+        val item = items[position]
+        holder.emoji.text = item.emoji
+        holder.title.text = item.title
+        holder.desc.text = item.desc
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
@@ -29,7 +29,8 @@ class OnboardingFragment : Fragment() {
         val emojis = resources.getStringArray(R.array.onboard_emojis)
         val titles = resources.getStringArray(R.array.onboard_titles)
         val descs = resources.getStringArray(R.array.onboard_descriptions)
-        val items = List(emojis.size) { i ->
+        val size = listOf(emojis.size, titles.size, descs.size).minOrNull() ?: 0
+        val items = List(size) { i ->
             OnboardingAdapter.Item(emojis[i], titles[i], descs[i])
         }
         viewPager = view.findViewById(R.id.viewPager)
@@ -58,7 +59,7 @@ class OnboardingFragment : Fragment() {
     }
 
     private fun updateButtonText() {
-        nextButton.text = if (::adapter.isInitialized && viewPager.currentItem == adapter.itemCount - 1) {
+        nextButton.text = if (::adapter.isInitialized && viewPager.currentItem >= adapter.itemCount - 1) {
             getString(R.string.onboarding_start)
         } else {
             getString(R.string.onboarding_next)

--- a/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
@@ -1,0 +1,67 @@
+package pw.idrug.connections.fragment
+
+import android.content.Intent
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.Fragment
+import androidx.viewpager2.widget.ViewPager2
+import pw.idrug.connections.R
+import pw.idrug.connections.activity.MainActivity
+
+class OnboardingFragment : Fragment() {
+
+    private lateinit var viewPager: ViewPager2
+    private lateinit var nextButton: Button
+    private lateinit var adapter: OnboardingAdapter
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return inflater.inflate(R.layout.fragment_onboarding, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        val emojis = resources.getStringArray(R.array.onboard_emojis)
+        val titles = resources.getStringArray(R.array.onboard_titles)
+        val descs = resources.getStringArray(R.array.onboard_descriptions)
+        val items = List(emojis.size) { i ->
+            OnboardingAdapter.Item(emojis[i], titles[i], descs[i])
+        }
+        viewPager = view.findViewById(R.id.viewPager)
+        nextButton = view.findViewById(R.id.button_next)
+        adapter = OnboardingAdapter(items)
+        viewPager.adapter = adapter
+
+        updateButtonText()
+
+        nextButton.setOnClickListener {
+            if (viewPager.currentItem < adapter.itemCount - 1) {
+                viewPager.currentItem = viewPager.currentItem + 1
+            } else {
+                startActivity(Intent(requireContext(), MainActivity::class.java).apply {
+                    putExtra(MainActivity.EXTRA_OPEN_ACCOUNT, true)
+                })
+                requireActivity().finish()
+            }
+        }
+
+        viewPager.registerOnPageChangeCallback(object : ViewPager2.OnPageChangeCallback() {
+            override fun onPageSelected(position: Int) {
+                updateButtonText()
+            }
+        })
+    }
+
+    private fun updateButtonText() {
+        nextButton.text = if (::adapter.isInitialized && viewPager.currentItem == adapter.itemCount - 1) {
+            getString(R.string.onboarding_start)
+        } else {
+            getString(R.string.onboarding_next)
+        }
+    }
+}

--- a/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/OnboardingFragment.kt
@@ -38,6 +38,15 @@ class OnboardingFragment : Fragment() {
         adapter = OnboardingAdapter(items)
         viewPager.adapter = adapter
 
+        if (adapter.itemCount == 0) {
+            // Nothing to show, immediately continue
+            startActivity(Intent(requireContext(), MainActivity::class.java).apply {
+                putExtra(MainActivity.EXTRA_OPEN_ACCOUNT, true)
+            })
+            requireActivity().finish()
+            return
+        }
+
         updateButtonText()
 
         nextButton.setOnClickListener {

--- a/ui/src/main/res/layout/activity_onboarding.xml
+++ b/ui/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/onboarding_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent" />

--- a/ui/src/main/res/layout/fragment_onboarding.xml
+++ b/ui/src/main/res/layout/fragment_onboarding.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <androidx.viewpager2.widget.ViewPager2
+        android:id="@+id/viewPager"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1" />
+
+    <Button
+        android:id="@+id/button_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/onboarding_next" />
+</LinearLayout>

--- a/ui/src/main/res/layout/item_onboard_card.xml
+++ b/ui/src/main/res/layout/item_onboard_card.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_margin="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="24dp"
+        android:gravity="center_horizontal">
+
+        <TextView
+            android:id="@+id/text_emoji"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textSize="48sp" />
+
+        <TextView
+            android:id="@+id/text_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textStyle="bold"
+            android:textSize="20sp" />
+
+        <TextView
+            android:id="@+id/text_desc"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAlignment="center" />
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -335,4 +335,30 @@
     <string name="invalid_response">Неверный ответ</string>
     <string name="code_invalid_or_expired">Код неверный или истёк</string>
     <string name="import_disclaimer">Убедитесь, что вы получили файл конфигурации в надёжном источнике.\n\nОфициальные сервисы iDrug Connections доступны только на сайте <a href="https://idrug.pw">idrug.pw</a>\n</string>
+    <string name="onboarding_next">Далее</string>
+    <string name="onboarding_start">Начать</string>
+    <string-array name="onboard_emojis">
+        <item>🔒</item>
+        <item>📡</item>
+        <item>📱</item>
+        <item>📺</item>
+        <item>🚦</item>
+        <item>💸</item>
+    </string-array>
+    <string-array name="onboard_titles">
+        <item>Анонимность без компромиссов</item>
+        <item>Мощные серверы по всему миру</item>
+        <item>Автозагрузка конфигов</item>
+        <item>Android TV поддержка</item>
+        <item>Раздельное туннелирование</item>
+        <item>Прозрачные тарифы</item>
+    </string-array>
+    <string-array name="onboard_descriptions">
+        <item>Твой реальный IP и действия надёжно скрыты. Мы не ведём логи. Всё, что делаешь — только твоё дело.</item>
+        <item>Локации — 🇩🇪 Германия, 🇸🇪 Швеция, 🇧🇬 Болгария, 🇪🇸 Испания и другие. Меняй страну за 1 клик.</item>
+        <item>Подключайся мгновенно. Конфиги и ключи автоматически сохраняются в приложении — ничего не теряется.</item>
+        <item>Удобное приложение для телевизоров — линкинг через код, запуск в 1 клик. Всё, как надо.</item>
+        <item>В настройках туннеля выбери приложения — их трафик пойдёт только через VPN, остальное напрямую.</item>
+        <item>Тарифы от 250₽ в месяц. Без скрытых платежей, оплата любым способом: карта, крипта, всё что удобно.</item>
+    </string-array>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -319,4 +319,30 @@
 
 Official iDrug Connections services are available only at <a href="https://idrug.pw">idrug.pw</a>
 </string>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_start">Start</string>
+    <string-array name="onboard_emojis">
+        <item>🔒</item>
+        <item>📡</item>
+        <item>📱</item>
+        <item>📺</item>
+        <item>🚦</item>
+        <item>💸</item>
+    </string-array>
+    <string-array name="onboard_titles">
+        <item>True Anonymity</item>
+        <item>Global Fast Servers</item>
+        <item>Auto Configs</item>
+        <item>Android TV ready</item>
+        <item>Split Tunneling</item>
+        <item>Transparent tariffs</item>
+    </string-array>
+    <string-array name="onboard_descriptions">
+        <item>Your real IP and actions are hidden. No logs. No tracking. Your privacy, your rules.</item>
+        <item>Locations: Germany, Sweden, Bulgaria, Spain, more. Switch countries in one tap.</item>
+        <item>Instant connection. Configs and keys are saved in-app — nothing gets lost.</item>
+        <item>Dedicated TV app — link by code, launch in one click. Pure comfort.</item>
+        <item>Pick apps for VPN in tunnel settings — only their traffic goes via VPN, the rest goes direct.</item>
+        <item>Plans from 250₽/month. No hidden fees, pay by card or crypto, whatever suits you.</item>
+    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- show onboarding screens if user isn't logged in
- handle navigation to Account tab and hide onboarding when logged in
- store slide texts in RU and EN string resources
- add viewpager2 dependency

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602511eb388326a8317cdab83c5d96