### PR TITLE
Add onboarding screens

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ jsr305 = "com.google.code.findbugs:jsr305:3.0.2"
 junit = "junit:junit:4.13.2"
 kotlinx-coroutines-android = "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3"
 zxing-android-embedded = "com.journeyapps:zxing-android-embedded:4.3.0"
+viewpager2 = "androidx.viewpager2:viewpager2:1.0.0"
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -84,6 +84,7 @@ dependencies {
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("com.google.zxing:core:3.5.1")
     implementation("com.squareup.picasso:picasso:2.71828")
+    implementation(libs.viewpager2)
     implementation("com.squareup.okhttp3:logging-interceptor:4.10.0") // опционально
 
     implementation(platform("com.google.firebase:firebase-bom:32.7.4"))

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -53,6 +53,9 @@
             android:theme="@style/NoBackgroundTheme" />
 
         <activity
+            android:name=".activity.OnboardingActivity"
+            android:exported="false" />
+        <activity
             android:name=".activity.MainActivity"
             android:exported="true">
             <intent-filter>

--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -25,6 +25,7 @@ import pw.idrug.connections.R
 import pw.idrug.connections.fragment.TunnelDetailFragment
 import pw.idrug.connections.fragment.TunnelEditorFragment
 import pw.idrug.connections.fragment.TunnelListFragment
+import pw.idrug.connections.activity.OnboardingActivity
 import pw.idrug.connections.fragment.AccountFragment
 import pw.idrug.connections.model.ObservableTunnel
 
@@ -67,6 +68,12 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val prefsAuth = getSharedPreferences("auth", Context.MODE_PRIVATE)
+        if (prefsAuth.getString("token", null).isNullOrEmpty()) {
+            startActivity(Intent(this, OnboardingActivity::class.java))
+            finish()
+            return
+        }
         setContentView(R.layout.main_activity)
         actionBar = supportActionBar
         isTwoPaneLayout = findViewById<View?>(R.id.master_detail_wrapper) != null

--- a/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/OnboardingActivity.kt
@@ -1,0 +1,124 @@
+package pw.idrug.connections.activity
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import android.widget.TextView
+import androidx.appcompat.app.AppCompatActivity
+import androidx.recyclerview.widget.RecyclerView
+import androidx.viewpager2.widget.ViewPager2
+import pw.idrug.connections.R
+
+class OnboardingActivity : AppCompatActivity() {
+
+    private lateinit var viewPager: ViewPager2
+    private lateinit var errorText: TextView
+    private lateinit var nextButton: Button
+    private lateinit var adapter: OnboardingAdapter
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        if (isLoggedIn()) {
+            startMain()
+            return
+        }
+        setContentView(R.layout.activity_onboarding)
+        viewPager = findViewById(R.id.view_pager)
+        errorText = findViewById(R.id.error_text)
+        nextButton = findViewById(R.id.btn_next)
+
+        val items = loadItems()
+        if (items.isEmpty()) {
+            viewPager.visibility = View.GONE
+            errorText.visibility = View.VISIBLE
+            nextButton.text = getString(android.R.string.ok)
+            nextButton.setOnClickListener { finish() }
+            return
+        }
+        adapter = OnboardingAdapter(items)
+        viewPager.adapter = adapter
+
+        nextButton.setOnClickListener {
+            val next = viewPager.currentItem + 1
+            if (next < adapter.itemCount) {
+                viewPager.currentItem = next
+            } else {
+                startActivity(Intent(this, LinkCodeActivity::class.java))
+                finish()
+            }
+        }
+    }
+
+    private fun isLoggedIn(): Boolean {
+        return try {
+            val prefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
+            !prefs.getString("token", null).isNullOrEmpty()
+        } catch (e: Exception) {
+            Log.w(TAG, "Unable to access preferences", e)
+            false
+        }
+    }
+
+    private fun loadItems(): List<OnboardingItem> {
+        val emojis = safeArray(R.array.onboarding_emojis)
+        val titles = safeArray(R.array.onboarding_titles)
+        val descs = safeArray(R.array.onboarding_descriptions)
+        val count = listOf(emojis.size, titles.size, descs.size).minOrNull() ?: 0
+        if (count == 0) return emptyList()
+        val list = mutableListOf<OnboardingItem>()
+        for (i in 0 until count) {
+            list.add(OnboardingItem(emojis[i], titles[i], descs[i]))
+        }
+        return list
+    }
+
+    private fun safeArray(resId: Int): Array<String> {
+        return try {
+            resources.getStringArray(resId)
+        } catch (e: Exception) {
+            Log.e(TAG, "Error loading array $resId", e)
+            emptyArray()
+        }
+    }
+
+    private fun startMain() {
+        startActivity(Intent(this, MainActivity::class.java))
+        finish()
+    }
+
+    data class OnboardingItem(val emoji: String, val title: String, val desc: String)
+
+    private class OnboardingAdapter(private val items: List<OnboardingItem>) :
+        RecyclerView.Adapter<OnboardingAdapter.ViewHolder>() {
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            val view = LayoutInflater.from(parent.context)
+                .inflate(R.layout.item_onboarding_card, parent, false)
+            return ViewHolder(view)
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            val item = items[position]
+            holder.emoji.text = item.emoji
+            holder.title.text = item.title
+            holder.desc.text = item.desc
+        }
+
+        override fun getItemCount(): Int = items.size
+
+        class ViewHolder(view: View) : RecyclerView.ViewHolder(view) {
+            val emoji: TextView = view.findViewById(R.id.text_emoji)
+            val title: TextView = view.findViewById(R.id.text_title)
+            val desc: TextView = view.findViewById(R.id.text_desc)
+        }
+    }
+
+    companion object {
+        private const val TAG = "OnboardingActivity"
+    }
+}

--- a/ui/src/main/res/layout/activity_onboarding.xml
+++ b/ui/src/main/res/layout/activity_onboarding.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <FrameLayout
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        android:layout_weight="1">
+
+        <androidx.viewpager2.widget.ViewPager2
+            android:id="@+id/view_pager"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <TextView
+            android:id="@+id/error_text"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:gravity="center"
+            android:text="@string/onboarding_error"
+            android:visibility="gone" />
+    </FrameLayout>
+
+    <Button
+        android:id="@+id/btn_next"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:text="@string/onboarding_next" />
+
+</LinearLayout>

--- a/ui/src/main/res/layout/item_onboarding_card.xml
+++ b/ui/src/main/res/layout/item_onboarding_card.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
+    android:padding="32dp">
+
+    <TextView
+        android:id="@+id/text_emoji"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:textSize="48sp" />
+
+    <TextView
+        android:id="@+id/text_title"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:textSize="20sp"
+        android:textStyle="bold" />
+
+    <TextView
+        android:id="@+id/text_desc"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:textAlignment="center"
+        android:textSize="16sp" />
+
+</LinearLayout>

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -335,4 +335,32 @@
     <string name="invalid_response">Неверный ответ</string>
     <string name="code_invalid_or_expired">Код неверный или истёк</string>
     <string name="import_disclaimer">Убедитесь, что вы получили файл конфигурации в надёжном источнике.\n\nОфициальные сервисы iDrug Connections доступны только на сайте <a href="https://idrug.pw">idrug.pw</a>\n</string>
+    <string-array name="onboarding_emojis">
+        <item>🔒</item>
+        <item>📡</item>
+        <item>📱</item>
+        <item>📺</item>
+        <item>🚦</item>
+        <item>💸</item>
+    </string-array>
+    <string-array name="onboarding_titles">
+        <item>Анонимность без компромиссов</item>
+        <item>Мощные серверы по всему миру</item>
+        <item>Автозагрузка конфигов</item>
+        <item>Android TV поддержка</item>
+        <item>Раздельное туннелирование</item>
+        <item>Прозрачные тарифы</item>
+    </string-array>
+    <string-array name="onboarding_descriptions">
+        <item>Твой реальный IP и действия надёжно скрыты. Мы не ведём логи. Всё, что делаешь — только твоё дело.</item>
+        <item>Локации — 🇩🇪 Германия, 🇸🇪 Швеция, 🇧🇬 Болгария, 🇪🇸 Испания и другие. Меняй страну за 1 клик.</item>
+        <item>Подключайся мгновенно. Конфиги и ключи автоматически сохраняются в приложении — ничего не теряется.</item>
+        <item>Удобное приложение для телевизоров — линкинг через код, запуск в 1 клик. Всё, как надо.</item>
+        <item>В настройках туннеля выбери приложения — их трафик пойдёт только через VPN, остальное напрямую.</item>
+        <item>Тарифы от 250₽ в месяц. Без скрытых платежей, оплата любым способом: карта, крипта, всё что удобно.</item>
+    </string-array>
+    <string name="onboarding_next">Далее</string>
+    <string name="onboarding_start">Начать</string>
+    <string name="onboarding_error">Ошибка загрузки обучения. Пожалуйста, обновите приложение или свяжитесь с поддержкой.</string>
 </resources>
+

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -319,4 +319,32 @@
 
 Official iDrug Connections services are available only at <a href="https://idrug.pw">idrug.pw</a>
 </string>
+    <string-array name="onboarding_emojis">
+        <item>🔒</item>
+        <item>📡</item>
+        <item>📱</item>
+        <item>📺</item>
+        <item>🚦</item>
+        <item>💸</item>
+    </string-array>
+    <string-array name="onboarding_titles">
+        <item>True Anonymity</item>
+        <item>Global Fast Servers</item>
+        <item>Auto Configs</item>
+        <item>Android TV ready</item>
+        <item>Split Tunneling</item>
+        <item>Transparent tariffs</item>
+    </string-array>
+    <string-array name="onboarding_descriptions">
+        <item>Your real IP and actions are hidden. No logs. No tracking. Your privacy, your rules.</item>
+        <item>Locations: Germany, Sweden, Bulgaria, Spain and more. Switch countries in one tap.</item>
+        <item>Instant connection. Configs and keys are saved in-app — nothing gets lost.</item>
+        <item>Dedicated TV app — link by code, launch in one click. Pure comfort.</item>
+        <item>Pick apps for VPN in tunnel settings — only their traffic goes via VPN, the rest goes direct.</item>
+        <item>Plans from 250₽/month. No hidden fees, pay by card or crypto, whatever suits you.</item>
+    </string-array>
+    <string name="onboarding_next">Next</string>
+    <string name="onboarding_start">Start</string>
+    <string name="onboarding_error">Onboarding failed to load. Please update the app or contact support.</string>
 </resources>
+


### PR DESCRIPTION
## Summary
- add onboarding screen activity with ViewPager2
- trigger onboarding from MainActivity when no auth token
- include English and Russian text for onboarding cards
- new layouts for onboarding card and activity
- include ViewPager2 dependency

## Testing
- `./gradlew help` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68602f0ef31c8326a9d36627ecb82153