### PR TITLE
Harden release build and manifest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ gradle.properties
 # Large binary files (optional, uncomment to exclude)
 # app/src/main/res/raw/*
 # app/src/main/assets/*
+keystore/

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ iDrugWG is the official VPN client from the iDrug team. It helps you stay online
 1. Clone the repository:
    `git clone https://github.com/bykkcs/idrugwg.git`
 2. Open in Android Studio.
-3. Build the APK:
-   `./gradlew assembleDebug`
+3. Generate a release APK with signing (set `RELEASE_STORE_PASSWORD` and
+   `RELEASE_KEY_PASSWORD` environment variables):
+   `./gradlew assembleRelease`
 4. Install on your device.
 
 ## Requirements

--- a/ui/build.gradle.kts
+++ b/ui/build.gradle.kts
@@ -13,6 +13,16 @@ plugins {
 }
 
 android {
+    signingConfigs {
+        create("release") {
+            storeFile = file("keystore/release.jks")
+            storePassword = System.getenv("RELEASE_STORE_PASSWORD")
+            keyAlias = "release"
+            keyPassword = System.getenv("RELEASE_KEY_PASSWORD")
+            enableV3Signing = true
+            enableV4Signing = true
+        }
+    }
     buildFeatures {
         buildConfig = true
         dataBinding = true
@@ -36,6 +46,8 @@ android {
             // Enable code shrinking and resource shrinking for production
             isMinifyEnabled = true
             isShrinkResources = true
+            isDebuggable = false
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles("proguard-android-optimize.txt", "proguard-rules.pro")
             packaging {
                 resources {
@@ -52,6 +64,7 @@ android {
         create("googleplay") {
             initWith(getByName("release"))
             matchingFallbacks += "release"
+            signingConfig = signingConfigs.getByName("release")
         }
     }
     androidResources {

--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -3,18 +3,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="internalOnly">
 
-    <uses-permission android:name="android.permission.REQUEST_INSTALL_PACKAGES" />
-    <uses-permission android:name="android.permission.CAMERA" />
+    <!-- Base permissions only -->
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
-    <uses-permission
-        android:name="android.permission.SYSTEM_ALERT_WINDOW"
-        android:minSdkVersion="34" />
-    <uses-permission
-        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"
-        tools:ignore="ScopedStorage" />
 
     <uses-feature
         android:name="android.hardware.touchscreen"
@@ -46,6 +38,11 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+
+        <!-- Digital Asset Links -->
+        <meta-data
+            android:name="asset_statements"
+            android:resource="@raw/asset_statements" />
 
         <activity
             android:name=".activity.TunnelToggleActivity"

--- a/ui/src/main/res/raw/asset_statements.json
+++ b/ui/src/main/res/raw/asset_statements.json
@@ -1,0 +1,9 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "web",
+      "site": "https://idrug.example.com"
+    }
+  }
+]


### PR DESCRIPTION
## Summary
- remove unnecessary permissions
- add asset statements for Digital Asset Links
- setup release signing configuration and disable debugging
- document building signed release APK
- ignore local keystore

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865751d118c83269819a6f5be676a8c