### PR TITLE
Fix tablet crash and immediate tunnel import display

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -39,6 +39,8 @@ import pw.idrug.connections.model.ObservableTunnel
 class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener {
     private var actionBar: ActionBar? = null
     private var isTwoPaneLayout = false
+    private val contentContainerId: Int
+        get() = if (isTwoPaneLayout) R.id.detail_container else R.id.fragment_container
     private var backPressedCallback: OnBackPressedCallback? = null
     private val notificationPermissionLauncher =
         registerForActivityResult(ActivityResultContracts.RequestPermission()) {}
@@ -147,7 +149,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
             }
 
             supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
+                .replace(contentContainerId, fragment)
                 .commit()
             bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
         }
@@ -198,7 +200,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
 
             R.id.menu_action_edit -> {
                 supportFragmentManager.commit {
-                    replace(R.id.fragment_container, TunnelEditorFragment())
+                    replace(contentContainerId, TunnelEditorFragment())
                     setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                     addToBackStack(null)
                 }
@@ -236,7 +238,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
         } else if (backStackEntries == 0) {
             // Show detail fragment
             fragmentManager.commit {
-                add(R.id.fragment_container, TunnelDetailFragment())
+                add(contentContainerId, TunnelDetailFragment())
                 setTransition(FragmentTransaction.TRANSIT_FRAGMENT_FADE)
                 addToBackStack(null)
             }
@@ -248,7 +250,7 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
         val fm = supportFragmentManager
         if (!fm.isStateSaved) {
             fm.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
+                .replace(contentContainerId, fragment)
                 .commit()
         }
     }

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -16,6 +16,7 @@ import com.google.zxing.qrcode.QRCodeWriter
 import com.squareup.picasso.Picasso
 import kotlinx.coroutines.MainScope
 import kotlinx.coroutines.launch
+import androidx.lifecycle.lifecycleScope
 import okhttp3.*
 import com.google.firebase.messaging.FirebaseMessaging
 import pw.idrug.connections.R
@@ -453,12 +454,11 @@ class AccountFragment : Fragment() {
             }
             downloadConfig(token, serverId) { success, configOrError ->
                 safeUi {
-                    setLoading(false)
                     if (success) {
-                        val file = File(requireContext().filesDir, "wg_$tunnelName.conf")
-                        file.writeText(configOrError ?: "")
-                        MainScope().launch {
+                        lifecycleScope.launch {
                             try {
+                                val file = File(requireContext().filesDir, "wg_$tunnelName.conf")
+                                file.writeText(configOrError ?: "")
                                 val config = Config.parse(file.bufferedReader())
                                 tunnelManager.create(tunnelName, config)
                                 file.delete()
@@ -466,10 +466,13 @@ class AccountFragment : Fragment() {
                                 loadProfileAndSetupUI(requireView())
                             } catch (e: Exception) {
                                 Toast.makeText(requireContext(), getString(R.string.tunnel_creation_error, e.message), Toast.LENGTH_LONG).show()
+                            } finally {
+                                setLoading(false)
                             }
                         }
                     } else {
                         Toast.makeText(requireContext(), getString(R.string.error_with_message, configOrError), Toast.LENGTH_LONG).show()
+                        setLoading(false)
                     }
                 }
             }
@@ -675,7 +678,7 @@ class AccountFragment : Fragment() {
                         for (server in toAdd) {
                             downloadConfig(token, server) { success, config ->
                                 if (success && config != null) {
-                                    MainScope().launch {
+                                    lifecycleScope.launch {
                                         try {
                                             val file = File(requireContext().filesDir, "wg_idrug_${server}.conf")
                                             file.writeText(config)


### PR DESCRIPTION
## Summary
- avoid tablet crash by using correct container id
- wait for tunnel creation to finish before hiding loader
- ensure background sync also uses lifecycle scope

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867eb475b5c8326935d34d5fe9f906c