### PR TITLE
Display VPN and account simultaneously on tablets

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -118,38 +118,45 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
             }
         }
 
-        // Open initial tab
+        // Open initial fragments
         if (savedInstanceState == null) {
-            val data = intent?.data
-            val openedViaDeepLink = intent?.action == Intent.ACTION_VIEW && data != null
-            val openAccountByIntent = intent?.getBooleanExtra(EXTRA_OPEN_ACCOUNT, false) == true ||
-                (openedViaDeepLink && data?.host == "auth")
-            val openAccountByTunnels = runBlocking {
-                try {
-                    Application.getTunnelManager().getTunnels().isEmpty()
-                } catch (e: Exception) {
-                    Log.w("MainActivity", "Unable to check tunnels", e)
-                    false
-                }
-            }
-            val openAccount = openAccountByIntent || openAccountByTunnels
-
-            val fragment: Fragment = if (openAccount) {
-                AccountFragment()
+            if (isTwoPaneLayout) {
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, TunnelListFragment())
+                    .replace(R.id.account_container, AccountFragment())
+                    .commit()
             } else {
-                val def = TunnelListFragment()
-                if (openedViaDeepLink && data?.scheme == "idrug" && data.host == "apps") {
-                    def.arguments = Bundle().apply {
-                        putString(TunnelListFragment.ARG_OPEN_TUNNEL_FOR_APPS, data.lastPathSegment)
+                val data = intent?.data
+                val openedViaDeepLink = intent?.action == Intent.ACTION_VIEW && data != null
+                val openAccountByIntent = intent?.getBooleanExtra(EXTRA_OPEN_ACCOUNT, false) == true ||
+                    (openedViaDeepLink && data?.host == "auth")
+                val openAccountByTunnels = runBlocking {
+                    try {
+                        Application.getTunnelManager().getTunnels().isEmpty()
+                    } catch (e: Exception) {
+                        Log.w("MainActivity", "Unable to check tunnels", e)
+                        false
                     }
                 }
-                def
-            }
+                val openAccount = openAccountByIntent || openAccountByTunnels
 
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .commit()
-            bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
+                val fragment: Fragment = if (openAccount) {
+                    AccountFragment()
+                } else {
+                    val def = TunnelListFragment()
+                    if (openedViaDeepLink && data?.scheme == "idrug" && data.host == "apps") {
+                        def.arguments = Bundle().apply {
+                            putString(TunnelListFragment.ARG_OPEN_TUNNEL_FOR_APPS, data.lastPathSegment)
+                        }
+                    }
+                    def
+                }
+
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, fragment)
+                    .commit()
+                bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
+            }
         }
 
         registerForFcm()

--- a/ui/src/main/res/layout-sw600dp/main_activity.xml
+++ b/ui/src/main/res/layout-sw600dp/main_activity.xml
@@ -16,15 +16,14 @@
         android:showDividers="middle">
 
         <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/list_fragment"
+            android:id="@+id/fragment_container"
             android:name="pw.idrug.connections.fragment.TunnelListFragment"
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="2"
-            android:tag="LIST" />
+            android:layout_weight="2" />
 
         <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/detail_container"
+            android:id="@+id/account_container"
             android:layout_width="0dp"
             android:layout_height="match_parent"
             android:layout_weight="3" />


### PR DESCRIPTION
## Summary
- update the tablet layout to include containers for VPN and account fragments
- load both fragments at startup when in two‑pane layout

## Testing
- `./gradlew tasks --all` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867feb9223c8326bba8c9175a5d830c