### PR TITLE
Simplify TV server list UI

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/activity/ConfigListActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/ConfigListActivity.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.Button
 import android.widget.TextView
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
@@ -28,13 +27,13 @@ class ConfigListActivity : AppCompatActivity() {
             pendingTunnel = null
         }
 
-    private lateinit var emptyView: TextView
+    private lateinit var emptyView: View
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_tv_config_list)
         val list = findViewById<RecyclerView>(R.id.config_list)
-        emptyView = findViewById(R.id.empty_view)
+        emptyView = findViewById(R.id.empty_state)
         adapter = TunnelAdapter()
         list.layoutManager = LinearLayoutManager(this)
         list.adapter = adapter
@@ -97,14 +96,11 @@ class ConfigListActivity : AppCompatActivity() {
 
     private inner class TunnelViewHolder(view: View) : RecyclerView.ViewHolder(view) {
         private val name: TextView = view.findViewById(R.id.config_name)
-        private val status: TextView = view.findViewById(R.id.config_status)
-        private val button: Button = view.findViewById(R.id.btn_connect)
         private lateinit var tunnel: ObservableTunnel
         fun bind(t: ObservableTunnel) {
             tunnel = t
             name.text = t.name.removePrefix("idrug_")
-            status.text = if (t.state == Tunnel.State.UP) getString(R.string.active) else getString(R.string.inactive)
-            button.setOnClickListener { requestToggle(tunnel) }
+            itemView.setOnClickListener { requestToggle(tunnel) }
         }
     }
 }

--- a/ui/src/main/java/pw/idrug/connections/activity/SplashActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/SplashActivity.kt
@@ -5,13 +5,15 @@ import android.content.Intent
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import android.util.Log
+import pw.idrug.connections.activity.ConfigListActivity
 import pw.idrug.connections.util.DeviceUtils
 
 class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (DeviceUtils.isTv(this)) {
-            val tvIntent = Intent(this, TvEntryActivity::class.java).apply {
+            val target = if (isLoggedIn()) ConfigListActivity::class.java else TvEntryActivity::class.java
+            val tvIntent = Intent(this, target).apply {
                 action = intent?.action
                 data = intent?.data
             }

--- a/ui/src/main/res/color/tv_card_stroke_color.xml
+++ b/ui/src/main/res/color/tv_card_stroke_color.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true" android:color="@color/tv_black" />
+    <item android:color="@android:color/transparent" />
+</selector>

--- a/ui/src/main/res/layout/activity_tv_config_list.xml
+++ b/ui/src/main/res/layout/activity_tv_config_list.xml
@@ -3,18 +3,46 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
-    android:padding="16dp">
+    android:background="@color/tv_white">
 
     <TextView
-        android:id="@+id/empty_view"
-        android:layout_width="wrap_content"
+        android:id="@+id/header_title"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:text="@string/no_configs"
-        android:visibility="gone"
-        android:layout_gravity="center_horizontal" />
+        android:gravity="center"
+        android:text="@string/tv_header_title"
+        android:textColor="@color/tv_black"
+        android:textSize="@dimen/tv_header_text_size"
+        android:paddingTop="@dimen/tv_card_padding"
+        android:paddingBottom="@dimen/tv_card_padding" />
+
+    <LinearLayout
+        android:id="@+id/empty_state"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:layout_width="@dimen/tv_empty_icon_size"
+            android:layout_height="@dimen/tv_empty_icon_size"
+            android:src="@drawable/ic_account_circle"
+            android:tint="@color/tv_black" />
+
+        <TextView
+            android:id="@+id/empty_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/tv_empty_text_margin"
+            android:text="@string/no_configs"
+            android:textColor="@color/tv_black"
+            android:textSize="@dimen/tv_item_text_size" />
+    </LinearLayout>
 
     <androidx.recyclerview.widget.RecyclerView
         android:id="@+id/config_list"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="0dp"
+        android:layout_weight="1" />
 </LinearLayout>

--- a/ui/src/main/res/layout/item_tv_config.xml
+++ b/ui/src/main/res/layout/item_tv_config.xml
@@ -1,26 +1,40 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="horizontal"
-    android:padding="12dp">
+    android:layout_marginVertical="8dp"
+    android:focusable="true"
+    android:clickable="true"
+    app:cardBackgroundColor="@color/tv_white"
+    app:strokeColor="@color/tv_card_stroke_color"
+    app:strokeWidth="@dimen/tv_card_border_width">
 
-    <TextView
-        android:id="@+id/config_name"
-        android:layout_width="0dp"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_weight="1"
-        android:textAppearance="?attr/textAppearanceHeadlineSmall" />
+        android:orientation="horizontal"
+        android:padding="@dimen/tv_card_padding"
+        android:gravity="center_vertical">
 
-    <TextView
-        android:id="@+id/config_status"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginEnd="12dp" />
+        <TextView
+            android:id="@+id/config_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:textColor="@color/tv_black"
+            android:textSize="@dimen/tv_item_text_size"
+            android:maxLines="1"
+            android:ellipsize="end" />
 
-    <Button
-        android:id="@+id/btn_connect"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:text="@string/connect" />
-</LinearLayout>
+        <Button
+            android:id="@+id/btn_connect"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:enabled="false"
+            android:focusable="false"
+            android:clickable="false"
+            android:text="@string/connect" />
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -82,4 +82,8 @@
     <color name="md_theme_dark_outlineVariant">#00FF00</color>
     <color name="md_theme_dark_scrim">#000000</color>
 
+    <!-- Simple palette for Android TV UI -->
+    <color name="tv_white">#FFFFFF</color>
+    <color name="tv_black">#000000</color>
+
 </resources>

--- a/ui/src/main/res/values/dimens.xml
+++ b/ui/src/main/res/values/dimens.xml
@@ -7,4 +7,12 @@
     <dimen name="bottom_sheet_top_padding">8dp</dimen>
     <dimen name="bottom_sheet_icon_padding">16dp</dimen>
     <dimen name="tunnel_list_placeholder_margin">16dp</dimen>
+
+    <!-- Dimensions for Android TV screens -->
+    <dimen name="tv_card_padding">32dp</dimen>
+    <dimen name="tv_card_border_width">2dp</dimen>
+    <dimen name="tv_item_text_size">24sp</dimen>
+    <dimen name="tv_header_text_size">28sp</dimen>
+    <dimen name="tv_empty_icon_size">96dp</dimen>
+    <dimen name="tv_empty_text_margin">16dp</dimen>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -330,6 +330,7 @@
 Official iDrug Connections services are available only at <a href="https://idrug.pw">idrug.pw</a>
 </string>
     <string name="connect">Connect</string>
+    <string name="tv_header_title">iDrug VPN</string>
     <string name="active">active</string>
     <string name="inactive">inactive</string>
     <string name="no_configs">Нет доступных конфигов</string>


### PR DESCRIPTION
## Summary
- redesign ConfigListActivity for Android TV
- show white cards with large text and button
- add header and empty state view
- store login session and skip code screen if logged in

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68680f15fd1883269d6cc03cbc10b308