### PR TITLE
Add TV server selection layout

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/activity/ConfigListActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/ConfigListActivity.kt
@@ -1,5 +1,6 @@
 package pw.idrug.connections.activity
 
+import android.content.Context
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -11,7 +12,15 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import org.json.JSONObject
+import pw.idrug.connections.config.Config
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
 import pw.idrug.connections.R
 import pw.idrug.connections.Application
 import pw.idrug.connections.backend.GoBackend
@@ -29,12 +38,14 @@ class ConfigListActivity : AppCompatActivity() {
         }
 
     private lateinit var emptyView: TextView
+    private lateinit var stateContainer: View
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_tv_config_list)
-        val list = findViewById<RecyclerView>(R.id.config_list)
-        emptyView = findViewById(R.id.empty_view)
+        setContentView(R.layout.activity_tv_server_selection)
+        val list = findViewById<RecyclerView>(R.id.server_list)
+        stateContainer = findViewById(R.id.state_container)
+        emptyView = findViewById(R.id.state_message)
         adapter = TunnelAdapter()
         list.layoutManager = LinearLayoutManager(this)
         list.adapter = adapter
@@ -42,7 +53,7 @@ class ConfigListActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        loadTunnels()
+        syncWithProfile()
     }
 
     private fun loadTunnels() {
@@ -50,8 +61,82 @@ class ConfigListActivity : AppCompatActivity() {
             val tunnels = Application.getTunnelManager().getTunnels()
             val data = tunnels.toList()
             adapter.update(data)
-            emptyView.visibility = if (data.isEmpty()) View.VISIBLE else View.GONE
+            if (data.isEmpty()) {
+                emptyView.text = getString(R.string.no_servers_found)
+                stateContainer.visibility = View.VISIBLE
+            } else {
+                stateContainer.visibility = View.GONE
+            }
         }
+    }
+
+    private fun syncWithProfile() {
+        val prefs = getSharedPreferences("auth", Context.MODE_PRIVATE)
+        val token = prefs.getString("token", null) ?: return
+        lifecycleScope.launch {
+            val client = OkHttpClient()
+            val request = Request.Builder()
+                .url("https://idrug.pw/api/profile")
+                .addHeader("Authorization", "Bearer $token")
+                .build()
+            val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+            if (!response.isSuccessful) {
+                emptyView.text = getString(R.string.error_loading_servers)
+                stateContainer.visibility = View.VISIBLE
+                loadTunnels()
+                return@launch
+            }
+            val body = response.body?.string() ?: run {
+                emptyView.text = getString(R.string.error_loading_servers)
+                stateContainer.visibility = View.VISIBLE
+                loadTunnels();
+                return@launch
+            }
+            try {
+                val obj = JSONObject(body)
+                val subs = obj.optJSONArray("subscriptions") ?: return@launch
+                val active = mutableSetOf<String>()
+                for (i in 0 until subs.length()) {
+                    val so = subs.getJSONObject(i)
+                    if (so.optBoolean("active", false)) {
+                        active.add(so.optString("location"))
+                    }
+                }
+                val tm = Application.getTunnelManager()
+                val tunnels = tm.getTunnels().toList()
+                val existing = tunnels.map { it.name }.toSet()
+                for (t in tunnels) {
+                    if (t.name.startsWith("idrug_") && t.name.removePrefix("idrug_") !in active) {
+                        tm.delete(t)
+                    }
+                }
+                for (server in active) {
+                    val name = "idrug_$server"
+                    if (name !in existing) {
+                        val cfg = downloadConfig(token, server)
+                        if (!cfg.isNullOrEmpty()) {
+                            val parsed = Config.parse(
+                                ByteArrayInputStream(cfg.toByteArray(StandardCharsets.UTF_8))
+                            )
+                            try { tm.create(name, parsed) } catch (_: Exception) {}
+                        }
+                    }
+                }
+            } catch (_: Exception) {
+            }
+            loadTunnels()
+        }
+    }
+
+    private suspend fun downloadConfig(token: String, serverId: String): String? {
+        val client = OkHttpClient()
+        val url = "https://idrug.pw/api/profile/download?server=$serverId"
+        val request = Request.Builder()
+            .url(url)
+            .addHeader("Authorization", "Bearer $token")
+            .build()
+        val response = withContext(Dispatchers.IO) { client.newCall(request).execute() }
+        return if (response.isSuccessful) response.body?.string() else null
     }
 
     private fun requestToggle(tunnel: ObservableTunnel) {
@@ -86,7 +171,7 @@ class ConfigListActivity : AppCompatActivity() {
         }
         override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): TunnelViewHolder {
             val view = LayoutInflater.from(parent.context)
-                .inflate(R.layout.item_tv_config, parent, false)
+                .inflate(R.layout.item_server_card, parent, false)
             return TunnelViewHolder(view)
         }
         override fun onBindViewHolder(holder: TunnelViewHolder, position: Int) {
@@ -96,14 +181,12 @@ class ConfigListActivity : AppCompatActivity() {
     }
 
     private inner class TunnelViewHolder(view: View) : RecyclerView.ViewHolder(view) {
-        private val name: TextView = view.findViewById(R.id.config_name)
-        private val status: TextView = view.findViewById(R.id.config_status)
+        private val name: TextView = view.findViewById(R.id.server_name)
         private val button: Button = view.findViewById(R.id.btn_connect)
         private lateinit var tunnel: ObservableTunnel
         fun bind(t: ObservableTunnel) {
             tunnel = t
             name.text = t.name.removePrefix("idrug_")
-            status.text = if (t.state == Tunnel.State.UP) getString(R.string.active) else getString(R.string.inactive)
             button.setOnClickListener { requestToggle(tunnel) }
         }
     }

--- a/ui/src/main/java/pw/idrug/connections/activity/SplashActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/SplashActivity.kt
@@ -11,7 +11,8 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         if (DeviceUtils.isTv(this)) {
-            val tvIntent = Intent(this, TvEntryActivity::class.java).apply {
+            val target = if (isLoggedIn()) ConfigListActivity::class.java else TvEntryActivity::class.java
+            val tvIntent = Intent(this, target).apply {
                 action = intent?.action
                 data = intent?.data
             }

--- a/ui/src/main/res/animator/card_focus_animator.xml
+++ b/ui/src/main/res/animator/card_focus_animator.xml
@@ -1,0 +1,14 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <set>
+            <objectAnimator android:propertyName="scaleX" android:valueTo="1.06" android:duration="150" android:valueType="floatType"/>
+            <objectAnimator android:propertyName="scaleY" android:valueTo="1.06" android:duration="150" android:valueType="floatType"/>
+        </set>
+    </item>
+    <item>
+        <set>
+            <objectAnimator android:propertyName="scaleX" android:valueTo="1" android:duration="150" android:valueType="floatType"/>
+            <objectAnimator android:propertyName="scaleY" android:valueTo="1" android:duration="150" android:valueType="floatType"/>
+        </set>
+    </item>
+</selector>

--- a/ui/src/main/res/drawable/card_focus_outline.xml
+++ b/ui/src/main/res/drawable/card_focus_outline.xml
@@ -1,0 +1,15 @@
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:state_focused="true">
+        <shape>
+            <solid android:color="@color/card_bg"/>
+            <stroke android:width="@dimen/focus_stroke_width" android:color="@color/focus_outline"/>
+            <corners android:radius="@dimen/card_corner_radius"/>
+        </shape>
+    </item>
+    <item>
+        <shape>
+            <solid android:color="@color/card_bg"/>
+            <corners android:radius="@dimen/card_corner_radius"/>
+        </shape>
+    </item>
+</selector>

--- a/ui/src/main/res/drawable/flag_placeholder.xml
+++ b/ui/src/main/res/drawable/flag_placeholder.xml
@@ -1,0 +1,7 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="64dp"
+    android:height="64dp"
+    android:viewportWidth="64"
+    android:viewportHeight="64">
+    <rect android:width="64" android:height="64" android:fillColor="#DDDDDD" />
+</vector>

--- a/ui/src/main/res/layout/activity_tv_server_selection.xml
+++ b/ui/src/main/res/layout/activity_tv_server_selection.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:padding="@dimen/large_margin">
+
+            <ImageView
+                android:id="@+id/logo_image"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:src="@drawable/logo"
+                android:contentDescription="@string/app_name"
+                android:layout_alignParentStart="true" />
+
+            <TextView
+                android:id="@+id/header_text"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/select_server"
+                android:textSize="@dimen/tv_header_text_size"
+                android:textStyle="bold"
+                android:textColor="@color/black"
+                android:layout_centerHorizontal="true" />
+        </RelativeLayout>
+
+        <androidx.recyclerview.widget.RecyclerView
+            android:id="@+id/server_list"
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_weight="1"
+            android:layout_marginStart="@dimen/large_margin"
+            android:layout_marginEnd="@dimen/large_margin"/>
+    </LinearLayout>
+
+    <LinearLayout
+        android:id="@+id/state_container"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ImageView
+            android:id="@+id/state_icon"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content" />
+
+        <TextView
+            android:id="@+id/state_message"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:textColor="@color/black"
+            android:textSize="@dimen/server_name_text_size"
+            android:layout_marginTop="@dimen/large_margin" />
+    </LinearLayout>
+
+</FrameLayout>

--- a/ui/src/main/res/layout/item_server_card.xml
+++ b/ui/src/main/res/layout/item_server_card.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginBottom="@dimen/large_margin"
+    android:clickable="true"
+    android:focusable="true"
+    android:foreground="?attr/selectableItemBackground"
+    android:background="@drawable/card_focus_outline"
+    app:cardElevation="@dimen/card_elevation"
+    app:cardUseCompatPadding="true"
+    app:stateListAnimator="@animator/card_focus_animator">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical"
+        android:padding="@dimen/large_padding">
+
+        <ImageView
+            android:id="@+id/server_icon"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:src="@drawable/flag_placeholder"
+            android:contentDescription="@string/location_label" />
+
+        <TextView
+            android:id="@+id/server_name"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/large_margin"
+            android:layout_weight="1"
+            android:textSize="@dimen/server_name_text_size"
+            android:textColor="@color/black"
+            android:textStyle="bold" />
+
+        <Button
+            android:id="@+id/btn_connect"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/connect"
+            android:enabled="false" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -372,5 +372,9 @@
     <string name="onboarding_next">Далее</string>
     <string name="onboarding_start">Начать</string>
     <string name="onboarding_error">Ошибка загрузки обучения. Пожалуйста, обновите приложение или свяжитесь с поддержкой.</string>
+
+    <!-- TV server list strings -->
+    <string name="no_servers_found">Серверы не найдены</string>
+    <string name="error_loading_servers">Ошибка загрузки списка серверов</string>
 </resources>
 

--- a/ui/src/main/res/values/colors.xml
+++ b/ui/src/main/res/values/colors.xml
@@ -82,4 +82,12 @@
     <color name="md_theme_dark_outlineVariant">#00FF00</color>
     <color name="md_theme_dark_scrim">#000000</color>
 
+    <!-- Generic colors used across TV layouts -->
+    <color name="white">#FFFFFF</color>
+    <color name="black">#000000</color>
+    <color name="primary">#6200EE</color>
+    <color name="accent">#03DAC5</color>
+    <color name="card_bg">#F5F5F5</color>
+    <color name="focus_outline">#FF6200EE</color>
+
 </resources>

--- a/ui/src/main/res/values/dimens.xml
+++ b/ui/src/main/res/values/dimens.xml
@@ -7,4 +7,13 @@
     <dimen name="bottom_sheet_top_padding">8dp</dimen>
     <dimen name="bottom_sheet_icon_padding">16dp</dimen>
     <dimen name="tunnel_list_placeholder_margin">16dp</dimen>
+
+    <!-- TV specific dimensions -->
+    <dimen name="tv_header_text_size">32sp</dimen>
+    <dimen name="server_name_text_size">24sp</dimen>
+    <dimen name="card_elevation">8dp</dimen>
+    <dimen name="large_padding">32dp</dimen>
+    <dimen name="large_margin">32dp</dimen>
+    <dimen name="card_corner_radius">8dp</dimen>
+    <dimen name="focus_stroke_width">2dp</dimen>
 </resources>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -360,5 +360,9 @@ Official iDrug Connections services are available only at <a href="https://idrug
     <string name="onboarding_next">Next</string>
     <string name="onboarding_start">Start</string>
     <string name="onboarding_error">Onboarding failed to load. Please update the app or contact support.</string>
+
+    <!-- TV server list strings -->
+    <string name="no_servers_found">No servers found</string>
+    <string name="error_loading_servers">Error loading servers</string>
 </resources>
 


### PR DESCRIPTION
## Summary
- design new Android TV layout for choosing VPN server
- add card item layout with focus scaling
- sync configs with backend in `ConfigListActivity`
- show server list after login on TV devices
- add related colors, dimens and strings

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686814d742048326b847e62e2db41239