### PR TITLE
Improve logout and tablet layout

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/MainActivity.kt
@@ -120,36 +120,38 @@ class MainActivity : BaseActivity(), FragmentManager.OnBackStackChangedListener 
 
         // Open initial tab
         if (savedInstanceState == null) {
-            val data = intent?.data
-            val openedViaDeepLink = intent?.action == Intent.ACTION_VIEW && data != null
-            val openAccountByIntent = intent?.getBooleanExtra(EXTRA_OPEN_ACCOUNT, false) == true ||
-                (openedViaDeepLink && data?.host == "auth")
-            val openAccountByTunnels = runBlocking {
-                try {
-                    Application.getTunnelManager().getTunnels().isEmpty()
-                } catch (e: Exception) {
-                    Log.w("MainActivity", "Unable to check tunnels", e)
-                    false
-                }
-            }
-            val openAccount = openAccountByIntent || openAccountByTunnels
-
-            val fragment: Fragment = if (openAccount) {
-                AccountFragment()
-            } else {
-                val def = TunnelListFragment()
-                if (openedViaDeepLink && data?.scheme == "idrug" && data.host == "apps") {
-                    def.arguments = Bundle().apply {
-                        putString(TunnelListFragment.ARG_OPEN_TUNNEL_FOR_APPS, data.lastPathSegment)
+            if (!isTwoPaneLayout) {
+                val data = intent?.data
+                val openedViaDeepLink = intent?.action == Intent.ACTION_VIEW && data != null
+                val openAccountByIntent = intent?.getBooleanExtra(EXTRA_OPEN_ACCOUNT, false) == true ||
+                    (openedViaDeepLink && data?.host == "auth")
+                val openAccountByTunnels = runBlocking {
+                    try {
+                        Application.getTunnelManager().getTunnels().isEmpty()
+                    } catch (e: Exception) {
+                        Log.w("MainActivity", "Unable to check tunnels", e)
+                        false
                     }
                 }
-                def
-            }
+                val openAccount = openAccountByIntent || openAccountByTunnels
 
-            supportFragmentManager.beginTransaction()
-                .replace(R.id.fragment_container, fragment)
-                .commit()
-            bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
+                val fragment: Fragment = if (openAccount) {
+                    AccountFragment()
+                } else {
+                    val def = TunnelListFragment()
+                    if (openedViaDeepLink && data?.scheme == "idrug" && data.host == "apps") {
+                        def.arguments = Bundle().apply {
+                            putString(TunnelListFragment.ARG_OPEN_TUNNEL_FOR_APPS, data.lastPathSegment)
+                        }
+                    }
+                    def
+                }
+
+                supportFragmentManager.beginTransaction()
+                    .replace(R.id.fragment_container, fragment)
+                    .commit()
+                bottomNavigation?.selectedItemId = if (openAccount) R.id.nav_account else R.id.nav_vpn
+            }
         }
 
         registerForFcm()

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -51,6 +51,7 @@ class AccountFragment : Fragment() {
     private var selectedServerName: String? = null
     private var serverList: List<Pair<String, String>> = listOf()
     private var qrPollingTimer: Timer? = null
+    private var isLogoutRunning = false
 
     // Subscription model. Only the active field matters.
     private data class Subscription(
@@ -404,20 +405,30 @@ class AccountFragment : Fragment() {
     }
 
     private fun afterLogout(view: View) {
+        if (isLogoutRunning) return
+        isLogoutRunning = true
+        setLoading(true)
         prefs.edit().clear().apply()
         MainScope().launch {
             try {
                 val tunnelManager = Application.getTunnelManager()
                 val tunnels = tunnelManager.getTunnels()
-                tunnels
-                    .filter { it.name.startsWith("idrug_") }
-                    .forEach { tunnel ->
+                tunnels.filter { it.name.startsWith("idrug_") }.forEach { tunnel ->
+                    try {
                         tunnelManager.delete(tunnel)
+                        Log.i("AccountFragment", "Tunnel deleted: ${'$'}{tunnel.name}")
+                    } catch (te: Exception) {
+                        Log.e("AccountFragment", "Tunnel delete error: ${'$'}{tunnel.name}", te)
                     }
-            } catch (e: Exception) {}
+                }
+            } catch (e: Exception) {
+                Log.e("AccountFragment", "Global logout error", e)
+            }
             safeUi {
                 showLoginScreen(view)
                 Toast.makeText(requireContext(), getString(R.string.logged_out), Toast.LENGTH_SHORT).show()
+                setLoading(false)
+                isLogoutRunning = false
             }
         }
     }

--- a/ui/src/main/res/layout-sw600dp/main_activity.xml
+++ b/ui/src/main/res/layout-sw600dp/main_activity.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:id="@+id/master_detail_wrapper"
+<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/main_activity_container"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="horizontal"
-    android:baselineAligned="false"
-    android:divider="?attr/dividerHorizontal"
-    android:showDividers="middle">
+    tools:context=".activity.MainActivity">
+
+    <LinearLayout
+        android:id="@+id/master_detail_wrapper"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="horizontal"
+        android:baselineAligned="false"
+        android:divider="?attr/dividerHorizontal"
+        android:showDividers="middle">
 
     <androidx.fragment.app.FragmentContainerView
         android:id="@+id/list_fragment"
@@ -24,3 +31,5 @@
         android:layout_weight="3" />
 
 </LinearLayout>
+
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/ui/src/main/res/layout-sw600dp/main_activity.xml
+++ b/ui/src/main/res/layout-sw600dp/main_activity.xml
@@ -1,33 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:id="@+id/main_activity_container"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/master_detail_wrapper"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    tools:context=".activity.MainActivity">
+    android:orientation="horizontal"
+    android:baselineAligned="false"
+    android:divider="?attr/dividerHorizontal"
+    android:showDividers="middle">
 
-    <LinearLayout
-        android:id="@+id/master_detail_wrapper"
-        android:layout_width="match_parent"
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/list_fragment"
+        android:name="pw.idrug.connections.fragment.TunnelListFragment"
+        android:layout_width="0dp"
         android:layout_height="match_parent"
-        android:baselineAligned="false"
-        android:divider="?attr/dividerHorizontal"
-        android:orientation="horizontal"
-        android:showDividers="middle">
+        android:layout_weight="2"
+        android:tag="LIST" />
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/list_fragment"
-            android:name="pw.idrug.connections.fragment.TunnelListFragment"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="2"
-            android:tag="LIST" />
+    <androidx.fragment.app.FragmentContainerView
+        android:id="@+id/fragment_container"
+        android:name="pw.idrug.connections.fragment.AccountFragment"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="3" />
 
-        <androidx.fragment.app.FragmentContainerView
-            android:id="@+id/detail_container"
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="3" />
-    </LinearLayout>
-
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>


### PR DESCRIPTION
## Summary
- handle re-entrant logout calls and cleanup tunnels
- show account fragment by default on tablets
- skip initial fragment replacement for two-pane layout

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68685036d08c83269afef8a567d626ec