### PR TITLE
Fix tunnel cleanup coroutine scopes

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -413,14 +413,16 @@ private fun afterLogout(view: View) {
 
     // Удаляем туннели сразу, синхронно!
     try {
-        val tunnelManager = Application.getTunnelManager()
-        val tunnels = tunnelManager.getTunnels()
-        tunnels.filter { it.name.startsWith("idrug_") }.forEach { tunnel ->
-            try {
-                tunnelManager.delete(tunnel)
-                Log.i("AccountFragment", "Tunnel deleted: ${tunnel.name}")
-            } catch (te: Exception) {
-                Log.e("AccountFragment", "Tunnel delete error: ${tunnel.name}", te)
+        runBlocking {
+            val tunnelManager = Application.getTunnelManager()
+            val tunnels = tunnelManager.getTunnels()
+            tunnels.filter { it.name.startsWith("idrug_") }.forEach { tunnel ->
+                try {
+                    tunnelManager.delete(tunnel)
+                    Log.i("AccountFragment", "Tunnel deleted: ${tunnel.name}")
+                } catch (te: Exception) {
+                    Log.e("AccountFragment", "Tunnel delete error: ${tunnel.name}", te)
+                }
             }
         }
     } catch (e: Exception) {
@@ -684,7 +686,7 @@ private fun afterLogout(view: View) {
                         activeServers.add(sObj.optString("location"))
                     }
                 }
-                MainScope().launch {
+                TunnelSyncManager.scope.launch {
                     val tunnelManager = Application.getTunnelManager()
                     val tunnels = tunnelManager.getTunnels().toList()
 


### PR DESCRIPTION
## Summary
- remove unused MainScope import
- use `TunnelSyncManager.scope` when cleaning tunnels after profile sync

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a72bf04f883269d88b9291894a781