### PR TITLE
Switch default theme to AppTheme

### DIFF
--- a/ui/src/main/AndroidManifest.xml
+++ b/ui/src/main/AndroidManifest.xml
@@ -45,7 +45,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/Theme.Idrug">
+        android:theme="@style/AppTheme">
 
         <activity
             android:name=".activity.TunnelToggleActivity"


### PR DESCRIPTION
## Summary
- use AppTheme as the application theme so Material2 is only applied to TV screens

## Testing
- `./gradlew test --no-daemon` *(fails: Gradle download runs but build aborted)*

------
https://chatgpt.com/codex/tasks/task_e_686a881b7a3083269426f4a7975f8e9b