### PR TITLE
Fix logout race and restore config actions

### DIFF
--- a/ui/src/debug/res/values/strings.xml
+++ b/ui/src/debug/res/values/strings.xml
@@ -258,7 +258,7 @@
     <string name="biometric_prompt_private_key_title">Authenticate to view private key</string>
     <string name="biometric_auth_error">Authentication failure</string>
     <string name="biometric_auth_error_reason">Authentication failure: %s</string>
-    <string name="login_via_telegram_or_qr">Login via Telegram or QR</string>
+    <string name="login_via_telegram_or_qr">Login via Telegram</string>
     <string name="login_via_telegram">Login via Telegram</string>
     <string name="choose_server">Choose server</string>
     <string name="download_config">Download config</string>

--- a/ui/src/main/java/pw/idrug/connections/activity/LinkCodeActivity.kt
+++ b/ui/src/main/java/pw/idrug/connections/activity/LinkCodeActivity.kt
@@ -43,7 +43,7 @@ class LinkCodeActivity : AppCompatActivity() {
                     startActivity(Intent(this, MainActivity::class.java))
                     finish()
                 } else {
-                    Toast.makeText(this, message ?: getString(R.string.login_via_telegram_or_qr), Toast.LENGTH_LONG).show()
+                    Toast.makeText(this, message ?: getString(R.string.login_via_telegram), Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -125,14 +125,8 @@ class AccountFragment : Fragment() {
             handleDownloadConfig()
         }
         view.findViewById<Button>(R.id.btn_link_device).setOnClickListener {
-            if (isLoggedIn()) {
-                pw.idrug.connections.dialog.LinkCodeDialogFragment()
-                    .show(parentFragmentManager, "link_code")
-            } else {
-                CodeInputDialogFragment { code ->
-                    handleLinkCodeLogin(code)
-                }.show(parentFragmentManager, "code_input")
-            }
+            pw.idrug.connections.dialog.LinkCodeDialogFragment()
+                .show(parentFragmentManager, "link_code")
         }
         view.findViewById<Button>(R.id.btn_renew).setOnClickListener {
             SubscriptionDialogFragment().show(parentFragmentManager, "subscription")
@@ -308,8 +302,7 @@ class AccountFragment : Fragment() {
     private fun showLoginScreen(view: View) {
         view.findViewById<Button>(R.id.btn_login_telegram).visibility = View.VISIBLE
         val linkButton = view.findViewById<Button>(R.id.btn_link_device)
-        linkButton.visibility = View.VISIBLE
-        linkButton.text = getString(R.string.login_with_code)
+        linkButton.visibility = View.GONE
         view.findViewById<Button>(R.id.btn_download).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_renew).visibility = View.GONE
         view.findViewById<Button>(R.id.btn_referral).visibility = View.GONE
@@ -317,7 +310,7 @@ class AccountFragment : Fragment() {
         view.findViewById<Spinner>(R.id.spinner_server).visibility = View.GONE
         view.findViewById<TextView>(R.id.text_server_choice).visibility = View.GONE
         view.findViewById<ImageView>(R.id.qr_code_image).visibility = View.GONE
-        view.findViewById<TextView>(R.id.text_current_user).text = getString(R.string.login_via_telegram_or_qr)
+        view.findViewById<TextView>(R.id.text_current_user).text = getString(R.string.login_via_telegram)
         view.findViewById<TextView>(R.id.status_text).text = ""
         view.findViewById<TextView>(R.id.text_expiration).text = ""
         view.findViewById<ImageView>(R.id.avatar_image).setImageResource(R.drawable.ic_avatar_placeholder)
@@ -465,7 +458,7 @@ private fun afterLogout(view: View) {
         setLoading(true)
         val token = prefs.getString("token", null)
         if (token == null) {
-            Toast.makeText(requireContext(), getString(R.string.login_via_telegram_or_qr), Toast.LENGTH_SHORT).show()
+            Toast.makeText(requireContext(), getString(R.string.login_via_telegram), Toast.LENGTH_SHORT).show()
             setLoading(false)
             return
         }
@@ -590,7 +583,7 @@ private fun afterLogout(view: View) {
                     Toast.makeText(requireContext(), getString(R.string.login_successful), Toast.LENGTH_SHORT).show()
                     showCorrectScreen(requireView())
                 } else {
-                    Toast.makeText(requireContext(), message ?: getString(R.string.login_via_telegram_or_qr), Toast.LENGTH_LONG).show()
+                    Toast.makeText(requireContext(), message ?: getString(R.string.login_via_telegram), Toast.LENGTH_LONG).show()
                 }
             }
         }

--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -173,6 +173,7 @@ class AccountFragment : Fragment() {
         client.newCall(Request.Builder().url(url).build()).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
                 safeUi {
+                    if (!isLoggedIn()) return@safeUi
                     serverList = listOf(
                         "germany" to getServerName("germany"),
                         "multihop" to getServerName("multihop"),
@@ -185,6 +186,7 @@ class AccountFragment : Fragment() {
             }
             override fun onResponse(call: Call, response: Response) {
                 safeUi {
+                    if (!isLoggedIn()) return@safeUi
                     if (response.isSuccessful) {
                         val arr = JSONArray(response.body?.string() ?: "[]")
                         serverList = List(arr.length()) {
@@ -252,6 +254,7 @@ class AccountFragment : Fragment() {
         client.newCall(request).enqueue(object : Callback {
             override fun onFailure(call: Call, e: IOException) {
                 safeUi {
+                    if (prefs.getString("token", null) != token) return@safeUi
                     setLoading(false)
                     Toast.makeText(requireContext(), getString(R.string.network_error_msg, e.message), Toast.LENGTH_SHORT).show()
                 }
@@ -259,6 +262,7 @@ class AccountFragment : Fragment() {
             override fun onResponse(call: Call, response: Response) {
                 val resp = response.body?.string() ?: ""
                 safeUi {
+                    if (prefs.getString("token", null) != token) return@safeUi
                     setLoading(false)
                     if (response.code == 401) {
                         showLoginScreen(view)
@@ -410,6 +414,8 @@ private fun afterLogout(view: View) {
     isLogoutRunning = true
     setLoading(true)
     prefs.edit().clear().apply()
+    qrPollingTimer?.cancel()
+    qrPollingTimer = null
 
     // Удаляем туннели сразу, синхронно!
     try {
@@ -433,6 +439,11 @@ private fun afterLogout(view: View) {
     TunnelSyncManager.cancelAll()
 
     safeUi {
+        if (isLoggedIn()) {
+            setLoading(false)
+            isLogoutRunning = false
+            return@safeUi
+        }
         showLoginScreen(view)
         Toast.makeText(requireContext(), getString(R.string.logged_out), Toast.LENGTH_SHORT).show()
         setLoading(false)

--- a/ui/src/main/res/layout/fragment_account.xml
+++ b/ui/src/main/res/layout/fragment_account.xml
@@ -49,7 +49,7 @@
                 android:id="@+id/text_current_user"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/login_via_telegram_or_qr"
+                android:text="@string/login_via_telegram"
                 android:textSize="18sp"
                 android:textStyle="bold"
                 android:paddingBottom="16dp"

--- a/ui/src/main/res/values-ru/strings.xml
+++ b/ui/src/main/res/values-ru/strings.xml
@@ -282,7 +282,7 @@
     <string name="biometric_auth_error">Ошибка аутентификации</string>
     <string name="biometric_auth_error_reason">Ошибка аутентификации: %s</string>
     <string name="account_avatar">Аватар пользователя</string>
-    <string name="login_via_telegram_or_qr">Вход через Telegram или QR</string>
+    <string name="login_via_telegram_or_qr">Вход через Telegram</string>
     <string name="login_via_telegram">Войти через Telegram</string>
     <string name="choose_server">Выберите сервер</string>
     <string name="download_config">Скачать конфиг</string>

--- a/ui/src/main/res/values/strings.xml
+++ b/ui/src/main/res/values/strings.xml
@@ -261,7 +261,7 @@
     <string name="biometric_auth_error">Authentication failure</string>
     <string name="account_avatar">User avatar</string>
     <string name="biometric_auth_error_reason">Authentication failure: %s</string>
-    <string name="login_via_telegram_or_qr">Login via Telegram or QR</string>
+    <string name="login_via_telegram_or_qr">Login via Telegram</string>
     <string name="login_via_telegram">Login via Telegram</string>
     <string name="choose_server">Choose server</string>
     <string name="download_config">Download config</string>


### PR DESCRIPTION
## Summary
- avoid stale callbacks when logging out
- cancel QR polling timer on logout
- ignore server/profile responses after logout

## Testing
- `./gradlew help` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a98042050832684065336fa5f2390