### PR TITLE
Delete downloaded configs on logout

### DIFF
--- a/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
+++ b/ui/src/main/java/pw/idrug/connections/fragment/AccountFragment.kt
@@ -428,6 +428,8 @@ private fun afterLogout(view: View) {
         Log.e("AccountFragment", "Error while deleting tunnels during logout", e)
     }
 
+    deleteDownloadedConfigs()
+
     // После логаута отменяем все операции синхронизации
     TunnelSyncManager.cancelAll()
 
@@ -443,6 +445,20 @@ private fun afterLogout(view: View) {
         isLogoutRunning = false
     }
 }
+
+    private fun deleteDownloadedConfigs() {
+        val filesDir = context?.filesDir ?: return
+        filesDir.listFiles()?.forEach { file ->
+            if (file.isFile && file.name.startsWith("wg_idrug_") && file.name.endsWith(".conf")) {
+                val deleted = file.delete()
+                if (!deleted) {
+                    Log.w("AccountFragment", "Failed to delete config file: ${file.absolutePath}")
+                } else {
+                    Log.i("AccountFragment", "Config file deleted: ${file.name}")
+                }
+            }
+        }
+    }
 
     private fun handleDownloadConfig() {
         if (selectedServerId == null) {


### PR DESCRIPTION
## Summary
- remove any locally downloaded iDrug configuration files during logout
- log successes or failures when deleting config artifacts

## Testing
- ./gradlew :ui:lint *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4a75fb810832685c68bebf8bc34b6